### PR TITLE
feat: 그룹 포트폴리오 비활성화 구현

### DIFF
--- a/src/app/application/group/command/disablePortfolio/DisablePortfolioCommand.ts
+++ b/src/app/application/group/command/disablePortfolio/DisablePortfolioCommand.ts
@@ -1,0 +1,8 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export class DisablePortfolioCommand implements ICommand {
+  constructor(
+    readonly groupId: string,
+    readonly requesterUserId: string,
+  ) {}
+}

--- a/src/app/application/group/command/disablePortfolio/DisablePortfolioCommandHandler.spec.ts
+++ b/src/app/application/group/command/disablePortfolio/DisablePortfolioCommandHandler.spec.ts
@@ -1,0 +1,98 @@
+import { Test } from '@nestjs/testing';
+import { advanceTo, clear } from 'jest-date-mock';
+
+import { DisablePortfolioCommand } from '@sight/app/application/group/command/disablePortfolio/DisablePortfolioCommand';
+import { DisablePortfolioCommandHandler } from '@sight/app/application/group/command/disablePortfolio/DisablePortfolioCommandHandler';
+
+import { Group } from '@sight/app/domain/group/model/Group';
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@sight/app/domain/group/IGroupRepository';
+
+import { DomainFixture } from '@sight/__test__/fixtures';
+import { Message } from '@sight/constant/message';
+
+describe('DisablePortfolioCommandHandler', () => {
+  let handler: DisablePortfolioCommandHandler;
+  let groupRepository: jest.Mocked<IGroupRepository>;
+
+  beforeAll(async () => {
+    advanceTo(new Date());
+
+    const testModule = await Test.createTestingModule({
+      providers: [
+        DisablePortfolioCommandHandler,
+        { provide: GroupRepository, useValue: {} },
+      ],
+    }).compile();
+
+    handler = testModule.get(DisablePortfolioCommandHandler);
+    groupRepository = testModule.get(GroupRepository);
+  });
+
+  afterAll(() => {
+    clear();
+  });
+
+  describe('handle', () => {
+    let group: Group;
+
+    const groupId = 'groupId';
+    const groupAdminUserId = 'groupAdminUserId';
+
+    beforeEach(() => {
+      group = DomainFixture.generateGroup({
+        adminUserId: groupAdminUserId,
+        hasPortfolio: true,
+      });
+
+      groupRepository.findById = jest.fn().mockResolvedValue(group);
+
+      groupRepository.save = jest.fn();
+    });
+
+    test('그룹이 존재하지 않는다면 예외를 발생시켜야 한다', async () => {
+      groupRepository.findById = jest.fn().mockResolvedValue(null);
+
+      await expect(
+        handler.execute(new DisablePortfolioCommand(groupId, groupAdminUserId)),
+      ).rejects.toThrowError(Message.GROUP_NOT_FOUND);
+    });
+
+    test('요청자가 그룹장이 아니라면 예외를 발생시켜야 한다', async () => {
+      const otherUserId = 'otherUserId';
+
+      await expect(
+        handler.execute(new DisablePortfolioCommand(groupId, otherUserId)),
+      ).rejects.toThrowError(Message.ONLY_GROUP_ADMIN_CAN_EDIT_GROUP);
+    });
+
+    test('그룹이 고객센터 그룹이라면 예외를 발생시켜야 한다', async () => {
+      jest.spyOn(group, 'isCustomerServiceGroup').mockReturnValue(true);
+
+      await expect(
+        handler.execute(new DisablePortfolioCommand(groupId, groupAdminUserId)),
+      ).rejects.toThrowError(Message.CANNOT_MODIFY_CUSTOMER_SERVICE_GROUP);
+    });
+
+    test('그룹의 포트폴리오를 비활성화 시켜야 한다', async () => {
+      jest.spyOn(group, 'disablePortfolio');
+
+      await handler.execute(
+        new DisablePortfolioCommand(groupId, groupAdminUserId),
+      );
+
+      expect(group.disablePortfolio).toBeCalled();
+    });
+
+    test('그룹을 저장해야 한다', async () => {
+      await handler.execute(
+        new DisablePortfolioCommand(groupId, groupAdminUserId),
+      );
+
+      expect(groupRepository.save).toBeCalledWith(group);
+      expect(groupRepository.save).toBeCalledTimes(1);
+    });
+  });
+});

--- a/src/app/application/group/command/disablePortfolio/DisablePortfolioCommandHandler.ts
+++ b/src/app/application/group/command/disablePortfolio/DisablePortfolioCommandHandler.ts
@@ -1,0 +1,48 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import {
+  ForbiddenException,
+  Inject,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+
+import { DisablePortfolioCommand } from '@sight/app/application/group/command/disablePortfolio/DisablePortfolioCommand';
+
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@sight/app/domain/group/IGroupRepository';
+
+import { Message } from '@sight/constant/message';
+
+@CommandHandler(DisablePortfolioCommand)
+export class DisablePortfolioCommandHandler
+  implements ICommandHandler<DisablePortfolioCommand>
+{
+  constructor(
+    @Inject(GroupRepository)
+    private readonly groupRepository: IGroupRepository,
+  ) {}
+
+  async execute(command: DisablePortfolioCommand): Promise<void> {
+    const { groupId, requesterUserId } = command;
+
+    const group = await this.groupRepository.findById(groupId);
+    if (!group) {
+      throw new NotFoundException(Message.GROUP_NOT_FOUND);
+    }
+
+    if (group.adminUserId !== requesterUserId) {
+      throw new ForbiddenException(Message.ONLY_GROUP_ADMIN_CAN_EDIT_GROUP);
+    }
+
+    if (group.isCustomerServiceGroup()) {
+      throw new UnprocessableEntityException(
+        Message.CANNOT_MODIFY_CUSTOMER_SERVICE_GROUP,
+      );
+    }
+
+    group.disablePortfolio();
+    await this.groupRepository.save(group);
+  }
+}

--- a/src/app/application/group/eventHandler/GroupCreatedHandler.ts
+++ b/src/app/application/group/eventHandler/GroupCreatedHandler.ts
@@ -39,7 +39,6 @@ export class GroupCreatedHandler implements IEventHandler<GroupCreated> {
     await this.userRepository.save(authorUser);
 
     this.slackSender.send({
-      sourceUserId: null,
       targetUserId: group.authorUserId,
       category: SlackMessageCategory.GROUP_ACTIVITY,
       message: `${group.title} 그룹을 만들었습니다.`,

--- a/src/app/application/group/eventHandler/GroupPortfolioDisabledHandler.spec.ts
+++ b/src/app/application/group/eventHandler/GroupPortfolioDisabledHandler.spec.ts
@@ -1,0 +1,155 @@
+import { Test } from '@nestjs/testing';
+import { advanceTo, clear } from 'jest-date-mock';
+import { ClsService } from 'nestjs-cls';
+
+import { IRequester } from '@sight/core/auth/IRequester';
+import { UserRole } from '@sight/core/auth/UserRole';
+import { MessageBuilder } from '@sight/core/message/MessageBuilder';
+
+import { GroupPortfolioDisabledHandler } from '@sight/app/application/group/eventHandler/GroupPortfolioDisabledHandler';
+
+import { PRACTICE_GROUP_ID } from '@sight/app/domain/group/model/constant';
+import { Group } from '@sight/app/domain/group/model/Group';
+import {
+  ISlackSender,
+  SlackSender,
+} from '@sight/app/domain/adapter/ISlackSender';
+import {
+  GroupLogger,
+  IGroupLogger,
+} from '@sight/app/domain/group/IGroupLogger';
+import {
+  GroupMemberRepository,
+  IGroupMemberRepository,
+} from '@sight/app/domain/group/IGroupMemberRepository';
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@sight/app/domain/group/IGroupRepository';
+import {
+  IUserRepository,
+  UserRepository,
+} from '@sight/app/domain/user/IUserRepository';
+
+import { DomainFixture } from '@sight/__test__/fixtures';
+import { Point } from '@sight/constant/point';
+
+describe('GroupPortfolioDisabledHandler', () => {
+  let handler: GroupPortfolioDisabledHandler;
+  let messageBuilder: MessageBuilder;
+  let clsService: jest.Mocked<ClsService>;
+  let groupRepository: jest.Mocked<IGroupRepository>;
+  let groupMemberRepository: jest.Mocked<IGroupMemberRepository>;
+  let userRepository: jest.Mocked<IUserRepository>;
+  let groupLogger: jest.Mocked<IGroupLogger>;
+  let slackSender: jest.Mocked<ISlackSender>;
+
+  beforeAll(async () => {
+    advanceTo(new Date());
+
+    const testModule = await Test.createTestingModule({
+      providers: [
+        GroupPortfolioDisabledHandler,
+        MessageBuilder,
+        { provide: ClsService, useValue: {} },
+        { provide: GroupRepository, useValue: {} },
+        { provide: GroupMemberRepository, useValue: {} },
+        { provide: UserRepository, useValue: {} },
+        { provide: GroupLogger, useValue: {} },
+        { provide: SlackSender, useValue: {} },
+      ],
+    }).compile();
+
+    handler = testModule.get(GroupPortfolioDisabledHandler);
+    messageBuilder = testModule.get(MessageBuilder);
+    clsService = testModule.get(ClsService);
+    groupRepository = testModule.get(GroupRepository);
+    groupMemberRepository = testModule.get(GroupMemberRepository);
+    userRepository = testModule.get(UserRepository);
+    groupLogger = testModule.get(GroupLogger);
+    slackSender = testModule.get(SlackSender);
+  });
+
+  afterAll(() => {
+    clear();
+  });
+
+  describe('handle', () => {
+    let group: Group;
+
+    const groupId = 'groupId';
+    const requester: IRequester = {
+      userId: 'requesterUserId',
+      role: UserRole.USER,
+    };
+
+    beforeEach(() => {
+      group = DomainFixture.generateGroup();
+
+      clsService.get = jest.fn().mockReturnValue(requester);
+      groupRepository.findById = jest.fn().mockResolvedValue(group);
+      groupMemberRepository.findByGroupId = jest.fn().mockResolvedValue([]);
+      userRepository.findByIds = jest.fn().mockResolvedValue([]);
+
+      jest.spyOn(messageBuilder, 'build');
+      groupLogger.log = jest.fn();
+      userRepository.save = jest.fn();
+      slackSender.send = jest.fn();
+    });
+
+    test('그룹이 존재하지 않으면 아무 동작도 하지 않아야 한다', async () => {
+      groupRepository.findById = jest.fn().mockResolvedValue(null);
+
+      await handler.handle({ groupId });
+
+      expect(groupRepository.findById).toBeCalledWith(groupId);
+    });
+
+    test('그룹 로그를 남겨야 한다', async () => {
+      await handler.handle({ groupId });
+
+      expect(groupLogger.log).toBeCalledTimes(1);
+    });
+
+    test('모든 그룹 멤버들에게서 포인트를 회수해야 한다', async () => {
+      const user = DomainFixture.generateUser();
+      const groupMember = DomainFixture.generateGroupMember({
+        userId: user.id,
+      });
+
+      groupMemberRepository.findByGroupId = jest
+        .fn()
+        .mockResolvedValue([groupMember]);
+      userRepository.findByIds = jest.fn().mockResolvedValue([user]);
+      jest.spyOn(user, 'grantPoint');
+
+      await handler.handle({ groupId });
+
+      expect(user.grantPoint).toBeCalledTimes(1);
+      expect(user.grantPoint).toBeCalledWith(
+        -Point.GROUP_ENABLED_PORTFOLIO,
+        expect.any(String),
+      );
+
+      expect(userRepository.save).toBeCalledTimes(1);
+      expect(userRepository.save).toBeCalledWith(user);
+    });
+
+    test('그룹 활용 실습 그룹이면 포인트를 회수하지 않아야 한다', async () => {
+      const practiceGroup = DomainFixture.generateGroup({
+        id: PRACTICE_GROUP_ID,
+      });
+      groupRepository.findById = jest.fn().mockResolvedValue(practiceGroup);
+
+      await handler.handle({ groupId });
+
+      expect(userRepository.save).not.toBeCalled();
+    });
+
+    test('메시지를 보내야 한다', async () => {
+      await handler.handle({ groupId });
+
+      expect(slackSender.send).toBeCalledTimes(1);
+    });
+  });
+});

--- a/src/app/application/group/eventHandler/GroupPortfolioDisabledHandler.ts
+++ b/src/app/application/group/eventHandler/GroupPortfolioDisabledHandler.ts
@@ -1,0 +1,101 @@
+import { Inject } from '@nestjs/common';
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+import { ClsService } from 'nestjs-cls';
+
+import { IRequester } from '@sight/core/auth/IRequester';
+import { Transactional } from '@sight/core/persistence/transaction/Transactional';
+
+import { GroupPortfolioDisabled } from '@sight/app/domain/group/event/GroupPortfolioDisabled';
+import { Group } from '@sight/app/domain/group/model/Group';
+import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
+import {
+  ISlackSender,
+  SlackSender,
+} from '@sight/app/domain/adapter/ISlackSender';
+import {
+  GroupLogger,
+  IGroupLogger,
+} from '@sight/app/domain/group/IGroupLogger';
+import {
+  GroupMemberRepository,
+  IGroupMemberRepository,
+} from '@sight/app/domain/group/IGroupMemberRepository';
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@sight/app/domain/group/IGroupRepository';
+import {
+  IUserRepository,
+  UserRepository,
+} from '@sight/app/domain/user/IUserRepository';
+
+import { Point } from '@sight/constant/point';
+import { MessageBuilder } from '@sight/core/message/MessageBuilder';
+import { Template } from '@sight/constant/template';
+
+@EventsHandler(GroupPortfolioDisabled)
+export class GroupPortfolioDisabledHandler
+  implements IEventHandler<GroupPortfolioDisabled>
+{
+  constructor(
+    private readonly clsService: ClsService,
+    private readonly messageBuilder: MessageBuilder,
+    @Inject(GroupRepository)
+    private readonly groupRepository: IGroupRepository,
+    @Inject(GroupMemberRepository)
+    private readonly groupMemberRepository: IGroupMemberRepository,
+    @Inject(UserRepository)
+    private readonly userRepository: IUserRepository,
+    @Inject(GroupLogger)
+    private readonly groupLogger: IGroupLogger,
+    @Inject(SlackSender)
+    private readonly slackSender: ISlackSender,
+  ) {}
+
+  @Transactional()
+  async handle(event: GroupPortfolioDisabled): Promise<void> {
+    const { groupId } = event;
+
+    const group = await this.groupRepository.findById(groupId);
+    if (!group) {
+      return;
+    }
+
+    await this.groupLogger.log(groupId, '포트폴리오 발행이 중단되었습니다.');
+    await this.retrievePointFromMembers(group);
+
+    const requester: IRequester = this.clsService.get('requester');
+    const message = this.messageBuilder.build(
+      Template.DISABLE_GROUP_PORTFOLIO.notification,
+      { groupId: group.id, groupTitle: group.title },
+    );
+
+    this.slackSender.send({
+      category: SlackMessageCategory.GROUP_ACTIVITY,
+      targetUserId: requester.userId,
+      message,
+    });
+  }
+
+  private async retrievePointFromMembers(group: Group): Promise<void> {
+    if (group.isPracticeGroup()) {
+      return;
+    }
+
+    const groupMembers = await this.groupMemberRepository.findByGroupId(
+      group.id,
+    );
+    const userIds = groupMembers.map((groupMember) => groupMember.userId);
+    const users = await this.userRepository.findByIds(userIds);
+
+    const reason = this.messageBuilder.build(
+      Template.DISABLE_GROUP_PORTFOLIO.point,
+      { groupTitle: group.title },
+    );
+
+    users.forEach((user) =>
+      user.grantPoint(-Point.GROUP_ENABLED_PORTFOLIO, reason),
+    );
+    await this.userRepository.save(...users);
+  }
+}

--- a/src/app/application/group/eventHandler/GroupPortfolioEnabledHandler.ts
+++ b/src/app/application/group/eventHandler/GroupPortfolioEnabledHandler.ts
@@ -76,7 +76,6 @@ export class GroupPortfolioEnabledHandler
     this.slackSender.send({
       category: SlackMessageCategory.GROUP_ACTIVITY,
       message: `<a href="/group/'${groupId}'"><u>${group.title}</u></a> 그룹의 <a href="/folio/'${groupId}'" target="_blank">포트폴리오</a>가 발행 중입니다.`,
-      sourceUserId: null,
       targetUserId: requester.userId, // TODO: 요청자 정보에 접근할 수 있을 때 수정
     });
   }

--- a/src/app/application/group/eventHandler/GroupStateChangedHandler.ts
+++ b/src/app/application/group/eventHandler/GroupStateChangedHandler.ts
@@ -56,7 +56,6 @@ export class GroupStateChangedHandler
     const members = await this.groupMemberRepository.findByGroupId(groupId);
     members.forEach((member) =>
       this.slackSender.send({
-        sourceUserId: null,
         targetUserId: member.userId,
         category: SlackMessageCategory.GROUP_ACTIVITY,
         message: `<a href="/group/${groupId}><u>${

--- a/src/app/application/group/eventHandler/GroupUpdatedHandler.ts
+++ b/src/app/application/group/eventHandler/GroupUpdatedHandler.ts
@@ -56,7 +56,6 @@ export class GroupUpdatedHandler implements IEventHandler<GroupUpdated> {
     const members = await this.groupMemberRepository.findByGroupId(groupId);
     members.forEach((member) =>
       this.slackSender.send({
-        sourceUserId: null,
         targetUserId: member.userId,
         category: SlackMessageCategory.GROUP_ACTIVITY,
         message,

--- a/src/app/application/user/eventHandler/UserProfileUpdatedHandler.ts
+++ b/src/app/application/user/eventHandler/UserProfileUpdatedHandler.ts
@@ -21,7 +21,6 @@ export class UserProfileUpdatedHandler
     const { user } = event;
 
     this.slackSender.send({
-      sourceUserId: null,
       targetUserId: user.id,
       message: '회원 정보를 수정했습니다.',
       category: SlackMessageCategory.USER_DATA,

--- a/src/app/domain/adapter/ISlackSender.ts
+++ b/src/app/domain/adapter/ISlackSender.ts
@@ -1,7 +1,7 @@
 import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
 
 export type SlackSendParams = {
-  sourceUserId: string | null;
+  sourceUserId?: string;
   targetUserId: string;
   message: string;
   category: SlackMessageCategory;

--- a/src/app/domain/group/event/GroupPortfolioDisabled.ts
+++ b/src/app/domain/group/event/GroupPortfolioDisabled.ts
@@ -1,0 +1,3 @@
+export class GroupPortfolioDisabled {
+  constructor(readonly groupId: string) {}
+}

--- a/src/app/domain/group/model/Group.spec.ts
+++ b/src/app/domain/group/model/Group.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@sight/app/domain/group/model/constant';
 
 import { DomainFixture } from '@sight/__test__/fixtures';
+import { Message } from '@sight/constant/message';
 
 describe('Group', () => {
   beforeAll(() => {
@@ -73,7 +74,31 @@ describe('Group', () => {
         hasPortfolio: true,
       });
 
-      expect(() => group.enablePortfolio()).toThrow();
+      expect(() => group.enablePortfolio()).toThrowError(
+        Message.ALREADY_GROUP_ENABLED_PORTFOLIO,
+      );
+    });
+  });
+
+  describe('disablePortfolio', () => {
+    test('포트폴리오를 비활성화해야 한다', () => {
+      const group = DomainFixture.generateGroup({
+        hasPortfolio: true,
+      });
+
+      group.disablePortfolio();
+
+      expect(group.hasPortfolio).toEqual(false);
+    });
+
+    test('이미 포트폴리오가 비활성화되어 있다면 예외를 발생시켜야 한다', () => {
+      const group = DomainFixture.generateGroup({
+        hasPortfolio: false,
+      });
+
+      expect(() => group.disablePortfolio()).toThrowError(
+        Message.ALREADY_GROUP_DISABLED_PORTFOLIO,
+      );
     });
   });
 

--- a/src/app/domain/group/model/Group.ts
+++ b/src/app/domain/group/model/Group.ts
@@ -176,6 +176,19 @@ export class Group extends AggregateRoot {
     this.apply(new GroupPortfolioEnabled(this.id));
   }
 
+  disablePortfolio(): void {
+    if (!this._hasPortfolio) {
+      throw new UnprocessableEntityException(
+        Message.ALREADY_GROUP_DISABLED_PORTFOLIO,
+      );
+    }
+
+    this._hasPortfolio = false;
+    this._updatedAt = new Date();
+
+    this.apply(new GroupPortfolioEnabled(this.id));
+  }
+
   isEditable(): boolean {
     return !this.isEnd() && !this.isCustomerServiceGroup();
   }

--- a/src/constant/template.ts
+++ b/src/constant/template.ts
@@ -1,0 +1,7 @@
+export const Template = {
+  DISABLE_GROUP_PORTFOLIO: {
+    notification:
+      '<a href="/group/:groupId:"><u>:groupTitle:</u></a> 그룹의 포트폴리오 발행이 중단되었습니다.',
+    point: '<u>:groupTitle:</u> 그룹의 포트폴리오가 발행되었습니다.',
+  },
+} as const;

--- a/src/core/message/MessageBuilder.spec.ts
+++ b/src/core/message/MessageBuilder.spec.ts
@@ -52,4 +52,18 @@ describe('MessageBuilder', () => {
 
     expect(actual).toEqual(expected);
   });
+
+  test('동일한 파라미터가 있는 메시지는 동일한 값을 사용해야 한다', () => {
+    const GIVEN_MESSAGE = ':some1: :some2: :some1: :some3: :some4:';
+    const expected = `1 2 1 3 4`;
+
+    const actual = messageBuilder.build(GIVEN_MESSAGE, {
+      some1: '1',
+      some2: '2',
+      some3: '3',
+      some4: '4',
+    });
+
+    expect(actual).toEqual(expected);
+  });
 });


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

그룹 포트폴리오 비활성화 기능을 구현합니다.
또, `ISlackSender`의 `send`에서 `sourceUserId`를 선택적으로 받도록 수정하였습니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

기존 기능입니다.