### PR TITLE
feat: 인증 단계에서 라라벨 세션을 공유하도록 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ test.sqlite3
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+.env.production

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/cqrs": "^10.2.5",
         "@nestjs/platform-express": "^10.0.0",
         "nestjs-cls": "^3.5.1",
+        "php-serialize": "^5.0.1",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1"
       },
@@ -8799,6 +8800,15 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.1.tgz",
       "integrity": "sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg=="
+    },
+    "node_modules/php-serialize": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/php-serialize/-/php-serialize-5.0.1.tgz",
+      "integrity": "sha512-+uxULDruX7uwGZmC1HjcvQMg6APyK1wzWXnaRR0Vxb7Vk4YMn5/Chp9tm+ccNqmXOtfZ/oZVbR8GZnPnojltDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/cqrs": "^10.2.5",
     "@nestjs/platform-express": "^10.0.0",
     "nestjs-cls": "^3.5.1",
+    "php-serialize": "^5.0.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"
   },

--- a/src/core/auth/ITokenVerifier.ts
+++ b/src/core/auth/ITokenVerifier.ts
@@ -1,7 +1,0 @@
-import { IRequester } from '@sight/core/auth/IRequester';
-
-export const TokenVerifier = Symbol('TokenVerifier');
-
-export interface ITokenVerifier {
-  verify: (token: string) => IRequester;
-}

--- a/src/core/auth/LaravelAuthnAdapter.ts
+++ b/src/core/auth/LaravelAuthnAdapter.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import fs from 'fs/promises';
+import crypto from 'crypto';
+import { unserialize } from 'php-serialize';
+
+import { LaravelSessionConfig } from '../config/LaravelSessionConfig';
+
+type EncryptedSession = {
+  iv: string;
+  value: string;
+  mac: string;
+};
+
+type SessionData = {
+  _token: string;
+  _previous: {
+    url: string;
+  };
+  _flash: {
+    old: any;
+    new: any;
+  };
+  [key: `login_${string}`]: number | undefined;
+};
+
+@Injectable()
+export class LaravelAuthnAdapter {
+  private readonly config: LaravelSessionConfig;
+
+  constructor(configService: ConfigService) {
+    this.config = configService.getOrThrow<LaravelSessionConfig>('session');
+  }
+
+  async authenticate(rawSession: string): Promise<string | null> {
+    const session = this.normalize(rawSession);
+    const decrypted = this.decrypt(session);
+
+    const sessionId = unserialize(decrypted);
+    const serializedSessionData = await this.getSessionData(sessionId);
+
+    const sessionData: SessionData = unserialize(serializedSessionData);
+    const userId = this.getUserId(sessionData);
+
+    return userId;
+  }
+
+  private normalize(session: string): EncryptedSession {
+    const urlDecoded = decodeURIComponent(session);
+    const base64Decoded = Buffer.from(urlDecoded, 'base64').toString('utf-8');
+    return JSON.parse(base64Decoded);
+  }
+
+  private decrypt(session: EncryptedSession): string {
+    const key = this.config.secret;
+
+    const iv = Buffer.from(session.iv, 'base64');
+    const value = Buffer.from(session.value, 'base64');
+
+    const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+    const decrypted = Buffer.concat([decipher.update(value), decipher.final()]);
+
+    const hash = crypto
+      .createHmac('sha256', key)
+      .update(session.iv + session.value)
+      .digest()
+      .toString('hex');
+
+    if (session.mac !== hash) {
+      throw new Error('Invalid MAC');
+    }
+
+    return decrypted.toString();
+  }
+
+  private async getSessionData(sessionId: string): Promise<string> {
+    const path = `${this.config.storagePath}/${sessionId}`;
+    return await fs.readFile(path, { encoding: 'utf8' });
+  }
+
+  private getUserId(sessionData: SessionData): string | null {
+    const loginKey = Object.keys(sessionData).find((key) =>
+      key.startsWith('login_'),
+    );
+    return loginKey ? String(sessionData[loginKey]) : null;
+  }
+}

--- a/src/core/auth/UserRole.ts
+++ b/src/core/auth/UserRole.ts
@@ -1,5 +1,5 @@
 export const UserRole = {
   USER: 'USER',
-  ADMIN: 'ADMIN',
+  MANAGER: 'MANAGER',
 } as const;
 export type UserRole = (typeof UserRole)[keyof typeof UserRole];

--- a/src/core/config/LaravelSessionConfig.ts
+++ b/src/core/config/LaravelSessionConfig.ts
@@ -1,0 +1,10 @@
+export type LaravelSessionConfig = {
+  secret: string;
+  storagePath: string;
+};
+
+// 레거시 시스템과의 호환성을 위해 Laravel 세션을 사용합니다.
+export const config = (): LaravelSessionConfig => ({
+  secret: process.env.APP_KEY || '',
+  storagePath: process.env.SESSION_STORAGE_PATH || '',
+});

--- a/src/core/config/index.ts
+++ b/src/core/config/index.ts
@@ -1,7 +1,10 @@
 import * as db from '@sight/core/config/DatabaseConfig';
+import * as session from '@sight/core/config/LaravelSessionConfig';
 
 export const configuration = (): {
   database: db.DatabaseConfig;
+  session: session.LaravelSessionConfig;
 } => ({
   database: db.config(),
+  session: session.config(),
 });


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

인증 단계에서 라라벨 세션을 공유하도록 구현합니다.
- `LaravelAuthnAdapter`를 구현하여 세션 정보로 요청자의 유저 ID를 가져올 수 있도록 구현합니다.
- `AuthGuard`에서 해당 어댑터를 활용하여 유저 정보를 가져오도록 구현합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

점진적 마이그레이션을 위해 기존 시스템인 라라벨과 인증 체계를 공유할 필요가 있습니다.
