### PR TITLE
ci: checkout, setup-node 액션의 버전 업그레이드

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,10 +14,10 @@ jobs:
     permissions: write-all
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
 


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

`actions/checkout`, `actions/setup-node`의 버전을 업그레이드합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

버전 차이로 인해 cache 처리에서 불필요하게 긴 시간이 소요됩니다. 관련 버그를 해결하기 위해 버전을 업그레이드합니다.
- https://github.com/actions/setup-node/issues/878