### PR TITLE
chore: import문 정렬 린트 추가 및 적용, import prefix 수정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint/eslint-plugin'],
+  plugins: ['@typescript-eslint/eslint-plugin', 'simple-import-sort'],
   extends: [
     'plugin:@typescript-eslint/recommended',
     'plugin:prettier/recommended',
@@ -27,5 +27,24 @@ module.exports = {
         endOfLine: 'auto',
       },
     ],
+    'simple-import-sort/imports': [
+      'error',
+      {
+        groups: [
+          ['^\\u0000'],
+          ['^node:'],
+          ['^@?\\w'],
+          ['^@khlug/core'],
+          ['^@khlug/\\w+/infra'],
+          ['^@khlug/\\w+/interface'],
+          ['^@khlug/\\w+/application'],
+          ['^@khlug/\\w+/domain'],
+          ['^@khlug'],
+          ['^'],
+          ['^\\.'],
+        ],
+      },
+    ],
+    'simple-import-sort/exports': 'error',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "eslint": "^8.42.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "jest": "^29.5.0",
         "jest-date-mock": "^1.0.8",
         "prettier": "^3.0.0",
@@ -5236,6 +5237,16 @@
         "eslint-config-prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "jest": "^29.5.0",
     "jest-date-mock": "^1.0.8",
     "prettier": "^3.0.0",
@@ -79,7 +80,7 @@
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",
     "moduleNameMapper": {
-      "@sight/(.*)": "<rootDir>/$1"
+      "@khlug/(.*)": "<rootDir>/$1"
     }
   }
 }

--- a/src/__test__/fixtures/GroupBookmarkFixture.ts
+++ b/src/__test__/fixtures/GroupBookmarkFixture.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker';
 import {
   GroupBookmark,
   GroupBookmarkConstructorParams,
-} from '@sight/app/domain/group/model/GroupBookmark';
+} from '@khlug/app/domain/group/model/GroupBookmark';
 
 function generator(
   params: Partial<GroupBookmarkConstructorParams> = {},

--- a/src/__test__/fixtures/GroupFixture.ts
+++ b/src/__test__/fixtures/GroupFixture.ts
@@ -1,16 +1,16 @@
 import { faker } from '@faker-js/faker';
+
 import {
   CUSTOMER_SERVICE_GROUP_ID,
   GroupAccessGrade,
   GroupCategory,
   GroupState,
   PRACTICE_GROUP_ID,
-} from '@sight/app/domain/group/model/constant';
-
+} from '@khlug/app/domain/group/model/constant';
 import {
   Group,
   GroupConstructorParams,
-} from '@sight/app/domain/group/model/Group';
+} from '@khlug/app/domain/group/model/Group';
 
 function generator(params: Partial<GroupConstructorParams> = {}): Group {
   return new Group({

--- a/src/__test__/fixtures/domain/group.ts
+++ b/src/__test__/fixtures/domain/group.ts
@@ -3,11 +3,11 @@ import { faker } from '@faker-js/faker';
 import {
   GroupLog,
   GroupLogConstructorParams,
-} from '@sight/app/domain/group/model/GroupLog';
+} from '@khlug/app/domain/group/model/GroupLog';
 import {
   GroupMember,
   GroupMemberConstructorParams,
-} from '@sight/app/domain/group/model/GroupMember';
+} from '@khlug/app/domain/group/model/GroupMember';
 
 export function generateGroupMember(
   params?: Partial<GroupMemberConstructorParams>,

--- a/src/__test__/fixtures/domain/index.ts
+++ b/src/__test__/fixtures/domain/index.ts
@@ -1,3 +1,3 @@
-export * from './user';
-export * from './interest';
 export * from './group';
+export * from './interest';
+export * from './user';

--- a/src/__test__/fixtures/domain/interest.ts
+++ b/src/__test__/fixtures/domain/interest.ts
@@ -1,9 +1,9 @@
 import { faker } from '@faker-js/faker';
 
 import {
-  InterestConstructorParams,
   Interest,
-} from '@sight/app/domain/interest/model/Interest';
+  InterestConstructorParams,
+} from '@khlug/app/domain/interest/model/Interest';
 
 export function generateInterest(
   params?: Partial<InterestConstructorParams>,

--- a/src/__test__/fixtures/domain/user.ts
+++ b/src/__test__/fixtures/domain/user.ts
@@ -1,12 +1,12 @@
 import { faker } from '@faker-js/faker';
 
-import { UserState } from '@sight/app/domain/user/model/constant';
-import { Profile } from '@sight/app/domain/user/model/Profile';
-import { User, UserConstructorParams } from '@sight/app/domain/user/model/User';
+import { UserState } from '@khlug/app/domain/user/model/constant';
 import {
   PointHistory,
   PointHistoryConstructorParams,
-} from '@sight/app/domain/user/model/PointHistory';
+} from '@khlug/app/domain/user/model/PointHistory';
+import { Profile } from '@khlug/app/domain/user/model/Profile';
+import { User, UserConstructorParams } from '@khlug/app/domain/user/model/User';
 
 export function generateUser(params?: Partial<UserConstructorParams>): User {
   return new User({

--- a/src/__test__/fixtures/view/group.ts
+++ b/src/__test__/fixtures/view/group.ts
@@ -1,14 +1,14 @@
 import { faker } from '@faker-js/faker';
 
-import { GroupListView } from '@sight/app/application/group/query/view/GroupListView';
-import { GroupMemberListView } from '@sight/app/application/group/query/view/GroupMemberListView';
-import { GroupMemberView } from '@sight/app/application/group/query/view/GroupMemberView';
-import { GroupView } from '@sight/app/application/group/query/view/GroupView';
+import { GroupListView } from '@khlug/app/application/group/query/view/GroupListView';
+import { GroupMemberListView } from '@khlug/app/application/group/query/view/GroupMemberListView';
+import { GroupMemberView } from '@khlug/app/application/group/query/view/GroupMemberView';
+import { GroupView } from '@khlug/app/application/group/query/view/GroupView';
 
 import {
   GroupCategory,
   GroupState,
-} from '@sight/app/domain/group/model/constant';
+} from '@khlug/app/domain/group/model/constant';
 
 export function generateGroupView(params?: Partial<GroupView>): GroupView {
   return {

--- a/src/__test__/fixtures/view/index.ts
+++ b/src/__test__/fixtures/view/index.ts
@@ -1,2 +1,2 @@
-export * from './user';
 export * from './group';
+export * from './user';

--- a/src/__test__/fixtures/view/user.ts
+++ b/src/__test__/fixtures/view/user.ts
@@ -1,11 +1,11 @@
 import { faker } from '@faker-js/faker';
 
-import { InterestListView } from '@sight/app/application/interest/query/view/InterestListView';
-import { InterestView } from '@sight/app/application/interest/query/view/InterestView';
-import { UserListView } from '@sight/app/application/user/query/view/UserListView';
-import { UserView } from '@sight/app/application/user/query/view/UserView';
+import { InterestListView } from '@khlug/app/application/interest/query/view/InterestListView';
+import { InterestView } from '@khlug/app/application/interest/query/view/InterestView';
+import { UserListView } from '@khlug/app/application/user/query/view/UserListView';
+import { UserView } from '@khlug/app/application/user/query/view/UserView';
 
-import { UserState } from '@sight/app/domain/user/model/constant';
+import { UserState } from '@khlug/app/domain/user/model/constant';
 
 export function generateUserView(params?: Partial<UserView>): UserView {
   return {

--- a/src/app/application/group/authorizer/GroupAuthorizer.spec.ts
+++ b/src/app/application/group/authorizer/GroupAuthorizer.spec.ts
@@ -1,18 +1,18 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { GroupAuthorizer } from '@sight/app/application/group/authorizer/GroupAuthorizer';
+import { GroupAuthorizer } from '@khlug/app/application/group/authorizer/GroupAuthorizer';
 
-import { User } from '@sight/app/domain/user/model/User';
 import {
   GroupAccessGrade,
   GroupCategory,
   ManagerOnlyGroupAccessGrade,
   ManagerOnlyGroupCategory,
-} from '@sight/app/domain/group/model/constant';
+} from '@khlug/app/domain/group/model/constant';
+import { User } from '@khlug/app/domain/user/model/User';
 
-import { DomainFixture } from '@sight/__test__/fixtures';
-import { Message } from '@sight/constant/message';
+import { DomainFixture } from '@khlug/__test__/fixtures';
+import { Message } from '@khlug/constant/message';
 
 describe('GroupAuthorizer', () => {
   let authorizer: GroupAuthorizer;

--- a/src/app/application/group/authorizer/GroupAuthorizer.ts
+++ b/src/app/application/group/authorizer/GroupAuthorizer.ts
@@ -1,14 +1,14 @@
 import { ForbiddenException, Injectable } from '@nestjs/common';
 
-import { User } from '@sight/app/domain/user/model/User';
 import {
   GroupAccessGrade,
   GroupCategory,
   ManagerOnlyGroupAccessGrade,
   ManagerOnlyGroupCategory,
-} from '@sight/app/domain/group/model/constant';
+} from '@khlug/app/domain/group/model/constant';
+import { User } from '@khlug/app/domain/user/model/User';
 
-import { Message } from '@sight/constant/message';
+import { Message } from '@khlug/constant/message';
 
 type CreateGroupParams = {
   user: User;

--- a/src/app/application/group/command/addBookmark/AddBookmarkCommandHandler.spec.ts
+++ b/src/app/application/group/command/addBookmark/AddBookmarkCommandHandler.spec.ts
@@ -1,23 +1,23 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { AddBookmarkCommand } from '@sight/app/application/group/command/addBookmark/AddBookmarkCommand';
-import { AddBookmarkCommandHandler } from '@sight/app/application/group/command/addBookmark/AddBookmarkCommandHandler';
+import { AddBookmarkCommand } from '@khlug/app/application/group/command/addBookmark/AddBookmarkCommand';
+import { AddBookmarkCommandHandler } from '@khlug/app/application/group/command/addBookmark/AddBookmarkCommandHandler';
 
-import { GroupBookmarkFactory } from '@sight/app/domain/group/GroupBookmarkFactory';
+import { SlackSender } from '@khlug/app/domain/adapter/ISlackSender';
+import { GroupBookmarkFactory } from '@khlug/app/domain/group/GroupBookmarkFactory';
 import {
   GroupBookmarkRepository,
   IGroupBookmarkRepository,
-} from '@sight/app/domain/group/IGroupBookmarkRepository';
+} from '@khlug/app/domain/group/IGroupBookmarkRepository';
 import {
   GroupRepository,
   IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
+} from '@khlug/app/domain/group/IGroupRepository';
 
-import { Message } from '@sight/constant/message';
-import { SlackSender } from '@sight/app/domain/adapter/ISlackSender';
-import { GroupFixture } from '@sight/__test__/fixtures/GroupFixture';
-import { GroupBookmarkFixture } from '@sight/__test__/fixtures/GroupBookmarkFixture';
+import { GroupBookmarkFixture } from '@khlug/__test__/fixtures/GroupBookmarkFixture';
+import { GroupFixture } from '@khlug/__test__/fixtures/GroupFixture';
+import { Message } from '@khlug/constant/message';
 
 describe('AddBookmarkCommandHandler', () => {
   let handler: AddBookmarkCommandHandler;

--- a/src/app/application/group/command/addBookmark/AddBookmarkCommandHandler.ts
+++ b/src/app/application/group/command/addBookmark/AddBookmarkCommandHandler.ts
@@ -1,33 +1,33 @@
-import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import {
   Inject,
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
-import { Transactional } from '@sight/core/persistence/transaction/Transactional';
+import { MessageBuilder } from '@khlug/core/message/MessageBuilder';
+import { Transactional } from '@khlug/core/persistence/transaction/Transactional';
 
-import { AddBookmarkCommand } from '@sight/app/application/group/command/addBookmark/AddBookmarkCommand';
-import { AddBookmarkCommandResult } from '@sight/app/application/group/command/addBookmark/AddBookmarkCommandResult';
+import { AddBookmarkCommand } from '@khlug/app/application/group/command/addBookmark/AddBookmarkCommand';
+import { AddBookmarkCommandResult } from '@khlug/app/application/group/command/addBookmark/AddBookmarkCommandResult';
 
-import { GroupBookmarkFactory } from '@sight/app/domain/group/GroupBookmarkFactory';
-import {
-  GroupBookmarkRepository,
-  IGroupBookmarkRepository,
-} from '@sight/app/domain/group/IGroupBookmarkRepository';
-import {
-  GroupRepository,
-  IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
-
-import { Message } from '@sight/constant/message';
-import { Template } from '@sight/constant/template';
 import {
   ISlackSender,
   SlackSender,
-} from '@sight/app/domain/adapter/ISlackSender';
-import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
-import { MessageBuilder } from '@sight/core/message/MessageBuilder';
+} from '@khlug/app/domain/adapter/ISlackSender';
+import { GroupBookmarkFactory } from '@khlug/app/domain/group/GroupBookmarkFactory';
+import {
+  GroupBookmarkRepository,
+  IGroupBookmarkRepository,
+} from '@khlug/app/domain/group/IGroupBookmarkRepository';
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@khlug/app/domain/group/IGroupRepository';
+import { SlackMessageCategory } from '@khlug/app/domain/message/model/constant';
+
+import { Message } from '@khlug/constant/message';
+import { Template } from '@khlug/constant/template';
 
 @CommandHandler(AddBookmarkCommand)
 export class AddBookmarkCommandHandler

--- a/src/app/application/group/command/addBookmark/AddBookmarkCommandResult.ts
+++ b/src/app/application/group/command/addBookmark/AddBookmarkCommandResult.ts
@@ -1,4 +1,4 @@
-import { GroupBookmark } from '@sight/app/domain/group/model/GroupBookmark';
+import { GroupBookmark } from '@khlug/app/domain/group/model/GroupBookmark';
 
 export class AddBookmarkCommandResult {
   constructor(readonly bookmark: GroupBookmark) {}

--- a/src/app/application/group/command/changeGroupState/ChangeGroupStateCommand.ts
+++ b/src/app/application/group/command/changeGroupState/ChangeGroupStateCommand.ts
@@ -1,4 +1,4 @@
-import { GroupState } from '@sight/app/domain/group/model/constant';
+import { GroupState } from '@khlug/app/domain/group/model/constant';
 
 type ChangeGroupStateRequester = {
   userId: string;

--- a/src/app/application/group/command/changeGroupState/ChangeGroupStateCommandHandler.spec.ts
+++ b/src/app/application/group/command/changeGroupState/ChangeGroupStateCommandHandler.spec.ts
@@ -1,24 +1,24 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { ChangeGroupStateCommand } from '@sight/app/application/group/command/changeGroupState/ChangeGroupStateCommand';
-import { ChangeGroupStateCommandHandler } from '@sight/app/application/group/command/changeGroupState/ChangeGroupStateCommandHandler';
-import { ChangeGroupStateCommandResult } from '@sight/app/application/group/command/changeGroupState/ChangeGroupStateCommandResult';
+import { ChangeGroupStateCommand } from '@khlug/app/application/group/command/changeGroupState/ChangeGroupStateCommand';
+import { ChangeGroupStateCommandHandler } from '@khlug/app/application/group/command/changeGroupState/ChangeGroupStateCommandHandler';
+import { ChangeGroupStateCommandResult } from '@khlug/app/application/group/command/changeGroupState/ChangeGroupStateCommandResult';
 
-import { GroupState } from '@sight/app/domain/group/model/constant';
-import { Group } from '@sight/app/domain/group/model/Group';
 import {
   GroupLogger,
   IGroupLogger,
-} from '@sight/app/domain/group/IGroupLogger';
+} from '@khlug/app/domain/group/IGroupLogger';
 import {
   GroupRepository,
   IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
+} from '@khlug/app/domain/group/IGroupRepository';
+import { GroupState } from '@khlug/app/domain/group/model/constant';
+import { Group } from '@khlug/app/domain/group/model/Group';
 
-import { generateEmptyProviders } from '@sight/__test__/util';
-import { Message } from '@sight/constant/message';
-import { GroupFixture } from '@sight/__test__/fixtures/GroupFixture';
+import { GroupFixture } from '@khlug/__test__/fixtures/GroupFixture';
+import { generateEmptyProviders } from '@khlug/__test__/util';
+import { Message } from '@khlug/constant/message';
 
 describe('ChangeGroupStateCommandHandler', () => {
   let handler: ChangeGroupStateCommandHandler;

--- a/src/app/application/group/command/changeGroupState/ChangeGroupStateCommandHandler.ts
+++ b/src/app/application/group/command/changeGroupState/ChangeGroupStateCommandHandler.ts
@@ -1,27 +1,27 @@
-import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import {
   ForbiddenException,
   Inject,
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
-import { Transactional } from '@sight/core/persistence/transaction/Transactional';
+import { Transactional } from '@khlug/core/persistence/transaction/Transactional';
 
-import { ChangeGroupStateCommand } from '@sight/app/application/group/command/changeGroupState/ChangeGroupStateCommand';
-import { ChangeGroupStateCommandResult } from '@sight/app/application/group/command/changeGroupState/ChangeGroupStateCommandResult';
+import { ChangeGroupStateCommand } from '@khlug/app/application/group/command/changeGroupState/ChangeGroupStateCommand';
+import { ChangeGroupStateCommandResult } from '@khlug/app/application/group/command/changeGroupState/ChangeGroupStateCommandResult';
 
-import { GroupState } from '@sight/app/domain/group/model/constant';
 import {
   GroupLogger,
   IGroupLogger,
-} from '@sight/app/domain/group/IGroupLogger';
+} from '@khlug/app/domain/group/IGroupLogger';
 import {
   GroupRepository,
   IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
+} from '@khlug/app/domain/group/IGroupRepository';
+import { GroupState } from '@khlug/app/domain/group/model/constant';
 
-import { Message } from '@sight/constant/message';
+import { Message } from '@khlug/constant/message';
 
 @CommandHandler(ChangeGroupStateCommand)
 export class ChangeGroupStateCommandHandler

--- a/src/app/application/group/command/changeGroupState/ChangeGroupStateCommandResult.ts
+++ b/src/app/application/group/command/changeGroupState/ChangeGroupStateCommandResult.ts
@@ -1,4 +1,4 @@
-import { Group } from '@sight/app/domain/group/model/Group';
+import { Group } from '@khlug/app/domain/group/model/Group';
 
 export class ChangeGroupStateCommandResult {
   constructor(readonly group: Group) {}

--- a/src/app/application/group/command/createGroup/CreateGroupCommand.ts
+++ b/src/app/application/group/command/createGroup/CreateGroupCommand.ts
@@ -1,9 +1,11 @@
 import { ICommand } from '@nestjs/cqrs';
+
 import {
   GroupAccessGrade,
   GroupCategory,
-} from '@sight/app/domain/group/model/constant';
-import { Typeof } from '@sight/util/types';
+} from '@khlug/app/domain/group/model/constant';
+
+import { Typeof } from '@khlug/util/types';
 
 export class CreateGroupCommand implements ICommand {
   readonly requesterUserId: string;

--- a/src/app/application/group/command/createGroup/CreateGroupCommandHandler.spec.ts
+++ b/src/app/application/group/command/createGroup/CreateGroupCommandHandler.spec.ts
@@ -1,34 +1,34 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { CreateGroupCommand } from '@sight/app/application/group/command/createGroup/CreateGroupCommand';
-import { CreateGroupCommandHandler } from '@sight/app/application/group/command/createGroup/CreateGroupCommandHandler';
+import { CreateGroupCommand } from '@khlug/app/application/group/command/createGroup/CreateGroupCommand';
+import { CreateGroupCommandHandler } from '@khlug/app/application/group/command/createGroup/CreateGroupCommandHandler';
 
-import { GroupFactory } from '@sight/app/domain/group/GroupFactory';
-import { GroupMemberFactory } from '@sight/app/domain/group/GroupMemberFactory';
+import { SlackSender } from '@khlug/app/domain/adapter/ISlackSender';
+import { GroupFactory } from '@khlug/app/domain/group/GroupFactory';
+import { GroupMemberFactory } from '@khlug/app/domain/group/GroupMemberFactory';
 import {
   GroupMemberRepository,
   IGroupMemberRepository,
-} from '@sight/app/domain/group/IGroupMemberRepository';
+} from '@khlug/app/domain/group/IGroupMemberRepository';
 import {
   GroupRepository,
   IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
+} from '@khlug/app/domain/group/IGroupRepository';
 import {
   GroupAccessGrade,
   GroupCategory,
-} from '@sight/app/domain/group/model/constant';
+} from '@khlug/app/domain/group/model/constant';
 import {
   IInterestRepository,
   InterestRepository,
-} from '@sight/app/domain/interest/IInterestRepository';
+} from '@khlug/app/domain/interest/IInterestRepository';
+import { PointGrantService } from '@khlug/app/domain/user/service/PointGrantService';
 
-import { Message } from '@sight/constant/message';
-import { SlackSender } from '@sight/app/domain/adapter/ISlackSender';
-import { GroupFixture } from '@sight/__test__/fixtures/GroupFixture';
-import { DomainFixture } from '@sight/__test__/fixtures';
-import { PointGrantService } from '@sight/app/domain/user/service/PointGrantService';
-import { Point } from '@sight/constant/point';
+import { DomainFixture } from '@khlug/__test__/fixtures';
+import { GroupFixture } from '@khlug/__test__/fixtures/GroupFixture';
+import { Message } from '@khlug/constant/message';
+import { Point } from '@khlug/constant/point';
 
 describe('CreateGroupCommandHandler', () => {
   let handler: CreateGroupCommandHandler;

--- a/src/app/application/group/command/createGroup/CreateGroupCommandHandler.ts
+++ b/src/app/application/group/command/createGroup/CreateGroupCommandHandler.ts
@@ -1,35 +1,35 @@
 import { Inject, NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
-import { Transactional } from '@sight/core/persistence/transaction/Transactional';
+import { Transactional } from '@khlug/core/persistence/transaction/Transactional';
 
-import { CreateGroupCommand } from '@sight/app/application/group/command/createGroup/CreateGroupCommand';
-import { CreateGroupCommandResult } from '@sight/app/application/group/command/createGroup/CreateGroupCommandResult';
+import { CreateGroupCommand } from '@khlug/app/application/group/command/createGroup/CreateGroupCommand';
+import { CreateGroupCommandResult } from '@khlug/app/application/group/command/createGroup/CreateGroupCommandResult';
 
-import { GroupFactory } from '@sight/app/domain/group/GroupFactory';
-import { GroupMemberFactory } from '@sight/app/domain/group/GroupMemberFactory';
-import { GroupState } from '@sight/app/domain/group/model/constant';
-import {
-  GroupMemberRepository,
-  IGroupMemberRepository,
-} from '@sight/app/domain/group/IGroupMemberRepository';
-import {
-  GroupRepository,
-  IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
-import {
-  IInterestRepository,
-  InterestRepository,
-} from '@sight/app/domain/interest/IInterestRepository';
 import {
   ISlackSender,
   SlackSender,
-} from '@sight/app/domain/adapter/ISlackSender';
+} from '@khlug/app/domain/adapter/ISlackSender';
+import { GroupFactory } from '@khlug/app/domain/group/GroupFactory';
+import { GroupMemberFactory } from '@khlug/app/domain/group/GroupMemberFactory';
+import {
+  GroupMemberRepository,
+  IGroupMemberRepository,
+} from '@khlug/app/domain/group/IGroupMemberRepository';
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@khlug/app/domain/group/IGroupRepository';
+import { GroupState } from '@khlug/app/domain/group/model/constant';
+import {
+  IInterestRepository,
+  InterestRepository,
+} from '@khlug/app/domain/interest/IInterestRepository';
+import { SlackMessageCategory } from '@khlug/app/domain/message/model/constant';
+import { PointGrantService } from '@khlug/app/domain/user/service/PointGrantService';
 
-import { Message } from '@sight/constant/message';
-import { Point } from '@sight/constant/point';
-import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
-import { PointGrantService } from '@sight/app/domain/user/service/PointGrantService';
+import { Message } from '@khlug/constant/message';
+import { Point } from '@khlug/constant/point';
 
 @CommandHandler(CreateGroupCommand)
 export class CreateGroupCommandHandler

--- a/src/app/application/group/command/createGroup/CreateGroupCommandResult.ts
+++ b/src/app/application/group/command/createGroup/CreateGroupCommandResult.ts
@@ -1,4 +1,4 @@
-import { Group } from '@sight/app/domain/group/model/Group';
+import { Group } from '@khlug/app/domain/group/model/Group';
 
 export class CreateGroupCommandResult {
   constructor(readonly group: Group) {}

--- a/src/app/application/group/command/disablePortfolio/DisablePortfolioCommandHandler.spec.ts
+++ b/src/app/application/group/command/disablePortfolio/DisablePortfolioCommandHandler.spec.ts
@@ -1,31 +1,31 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { DisablePortfolioCommand } from '@sight/app/application/group/command/disablePortfolio/DisablePortfolioCommand';
-import { DisablePortfolioCommandHandler } from '@sight/app/application/group/command/disablePortfolio/DisablePortfolioCommandHandler';
+import { DisablePortfolioCommand } from '@khlug/app/application/group/command/disablePortfolio/DisablePortfolioCommand';
+import { DisablePortfolioCommandHandler } from '@khlug/app/application/group/command/disablePortfolio/DisablePortfolioCommandHandler';
 
-import {
-  GroupRepository,
-  IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
-
-import {
-  GroupMemberRepository,
-  IGroupMemberRepository,
-} from '@sight/app/domain/group/IGroupMemberRepository';
-import {
-  GroupLogger,
-  IGroupLogger,
-} from '@sight/app/domain/group/IGroupLogger';
 import {
   ISlackSender,
   SlackSender,
-} from '@sight/app/domain/adapter/ISlackSender';
-import { Message } from '@sight/constant/message';
-import { GroupFixture } from '@sight/__test__/fixtures/GroupFixture';
-import { PointGrantService } from '@sight/app/domain/user/service/PointGrantService';
-import { DomainFixture } from '@sight/__test__/fixtures';
-import { Point } from '@sight/constant/point';
+} from '@khlug/app/domain/adapter/ISlackSender';
+import {
+  GroupLogger,
+  IGroupLogger,
+} from '@khlug/app/domain/group/IGroupLogger';
+import {
+  GroupMemberRepository,
+  IGroupMemberRepository,
+} from '@khlug/app/domain/group/IGroupMemberRepository';
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@khlug/app/domain/group/IGroupRepository';
+import { PointGrantService } from '@khlug/app/domain/user/service/PointGrantService';
+
+import { DomainFixture } from '@khlug/__test__/fixtures';
+import { GroupFixture } from '@khlug/__test__/fixtures/GroupFixture';
+import { Message } from '@khlug/constant/message';
+import { Point } from '@khlug/constant/point';
 
 describe('DisablePortfolioCommandHandler', () => {
   let handler: DisablePortfolioCommandHandler;

--- a/src/app/application/group/command/disablePortfolio/DisablePortfolioCommandHandler.ts
+++ b/src/app/application/group/command/disablePortfolio/DisablePortfolioCommandHandler.ts
@@ -1,39 +1,39 @@
-import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import {
   ForbiddenException,
   Inject,
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
-import { Transactional } from '@sight/core/persistence/transaction/Transactional';
+import { MessageBuilder } from '@khlug/core/message/MessageBuilder';
+import { Transactional } from '@khlug/core/persistence/transaction/Transactional';
 
-import { DisablePortfolioCommand } from '@sight/app/application/group/command/disablePortfolio/DisablePortfolioCommand';
+import { DisablePortfolioCommand } from '@khlug/app/application/group/command/disablePortfolio/DisablePortfolioCommand';
 
 import {
-  GroupRepository,
-  IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
-
-import { Message } from '@sight/constant/message';
-import {
-  SlackSender,
   ISlackSender,
-} from '@sight/app/domain/adapter/ISlackSender';
+  SlackSender,
+} from '@khlug/app/domain/adapter/ISlackSender';
 import {
   GroupLogger,
   IGroupLogger,
-} from '@sight/app/domain/group/IGroupLogger';
+} from '@khlug/app/domain/group/IGroupLogger';
 import {
   GroupMemberRepository,
   IGroupMemberRepository,
-} from '@sight/app/domain/group/IGroupMemberRepository';
-import { Group } from '@sight/app/domain/group/model/Group';
-import { Template } from '@sight/constant/template';
-import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
-import { Point } from '@sight/constant/point';
-import { PointGrantService } from '@sight/app/domain/user/service/PointGrantService';
-import { MessageBuilder } from '@sight/core/message/MessageBuilder';
+} from '@khlug/app/domain/group/IGroupMemberRepository';
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@khlug/app/domain/group/IGroupRepository';
+import { Group } from '@khlug/app/domain/group/model/Group';
+import { SlackMessageCategory } from '@khlug/app/domain/message/model/constant';
+import { PointGrantService } from '@khlug/app/domain/user/service/PointGrantService';
+
+import { Message } from '@khlug/constant/message';
+import { Point } from '@khlug/constant/point';
+import { Template } from '@khlug/constant/template';
 
 @CommandHandler(DisablePortfolioCommand)
 export class DisablePortfolioCommandHandler

--- a/src/app/application/group/command/enablePortfolio/EnablePortfolioCommandHandler.spec.ts
+++ b/src/app/application/group/command/enablePortfolio/EnablePortfolioCommandHandler.spec.ts
@@ -1,31 +1,31 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { EnablePortfolioCommand } from '@sight/app/application/group/command/enablePortfolio/EnablePortfolioCommand';
-import { EnablePortfolioCommandHandler } from '@sight/app/application/group/command/enablePortfolio/EnablePortfolioCommandHandler';
+import { EnablePortfolioCommand } from '@khlug/app/application/group/command/enablePortfolio/EnablePortfolioCommand';
+import { EnablePortfolioCommandHandler } from '@khlug/app/application/group/command/enablePortfolio/EnablePortfolioCommandHandler';
 
-import {
-  GroupRepository,
-  IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
-
-import { Message } from '@sight/constant/message';
-import { GroupFixture } from '@sight/__test__/fixtures/GroupFixture';
-import {
-  GroupMemberRepository,
-  IGroupMemberRepository,
-} from '@sight/app/domain/group/IGroupMemberRepository';
-import {
-  GroupLogger,
-  IGroupLogger,
-} from '@sight/app/domain/group/IGroupLogger';
-import { PointGrantService } from '@sight/app/domain/user/service/PointGrantService';
 import {
   ISlackSender,
   SlackSender,
-} from '@sight/app/domain/adapter/ISlackSender';
-import { DomainFixture } from '@sight/__test__/fixtures';
-import { Point } from '@sight/constant/point';
+} from '@khlug/app/domain/adapter/ISlackSender';
+import {
+  GroupLogger,
+  IGroupLogger,
+} from '@khlug/app/domain/group/IGroupLogger';
+import {
+  GroupMemberRepository,
+  IGroupMemberRepository,
+} from '@khlug/app/domain/group/IGroupMemberRepository';
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@khlug/app/domain/group/IGroupRepository';
+import { PointGrantService } from '@khlug/app/domain/user/service/PointGrantService';
+
+import { DomainFixture } from '@khlug/__test__/fixtures';
+import { GroupFixture } from '@khlug/__test__/fixtures/GroupFixture';
+import { Message } from '@khlug/constant/message';
+import { Point } from '@khlug/constant/point';
 
 describe('EnablePortfolioCommandHandler', () => {
   let handler: EnablePortfolioCommandHandler;

--- a/src/app/application/group/command/enablePortfolio/EnablePortfolioCommandHandler.ts
+++ b/src/app/application/group/command/enablePortfolio/EnablePortfolioCommandHandler.ts
@@ -1,39 +1,39 @@
-import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import {
   ForbiddenException,
   Inject,
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
-import { Transactional } from '@sight/core/persistence/transaction/Transactional';
+import { MessageBuilder } from '@khlug/core/message/MessageBuilder';
+import { Transactional } from '@khlug/core/persistence/transaction/Transactional';
 
-import { EnablePortfolioCommand } from '@sight/app/application/group/command/enablePortfolio/EnablePortfolioCommand';
+import { EnablePortfolioCommand } from '@khlug/app/application/group/command/enablePortfolio/EnablePortfolioCommand';
 
-import {
-  GroupRepository,
-  IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
-
-import { Message } from '@sight/constant/message';
-import { Group } from '@sight/app/domain/group/model/Group';
-import { Template } from '@sight/constant/template';
-import {
-  GroupMemberRepository,
-  IGroupMemberRepository,
-} from '@sight/app/domain/group/IGroupMemberRepository';
-import {
-  GroupLogger,
-  IGroupLogger,
-} from '@sight/app/domain/group/IGroupLogger';
 import {
   ISlackSender,
   SlackSender,
-} from '@sight/app/domain/adapter/ISlackSender';
-import { MessageBuilder } from '@sight/core/message/MessageBuilder';
-import { PointGrantService } from '@sight/app/domain/user/service/PointGrantService';
-import { Point } from '@sight/constant/point';
-import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
+} from '@khlug/app/domain/adapter/ISlackSender';
+import {
+  GroupLogger,
+  IGroupLogger,
+} from '@khlug/app/domain/group/IGroupLogger';
+import {
+  GroupMemberRepository,
+  IGroupMemberRepository,
+} from '@khlug/app/domain/group/IGroupMemberRepository';
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@khlug/app/domain/group/IGroupRepository';
+import { Group } from '@khlug/app/domain/group/model/Group';
+import { SlackMessageCategory } from '@khlug/app/domain/message/model/constant';
+import { PointGrantService } from '@khlug/app/domain/user/service/PointGrantService';
+
+import { Message } from '@khlug/constant/message';
+import { Point } from '@khlug/constant/point';
+import { Template } from '@khlug/constant/template';
 
 @CommandHandler(EnablePortfolioCommand)
 export class EnablePortfolioCommandHandler

--- a/src/app/application/group/command/modifyGroup/ModifyGroupCommand.ts
+++ b/src/app/application/group/command/modifyGroup/ModifyGroupCommand.ts
@@ -1,8 +1,9 @@
 import { ICommand } from '@nestjs/cqrs';
+
 import {
   GroupAccessGrade,
   GroupCategory,
-} from '@sight/app/domain/group/model/constant';
+} from '@khlug/app/domain/group/model/constant';
 
 export type ModifyGroupParams = {
   readonly title: string;

--- a/src/app/application/group/command/modifyGroup/ModifyGroupCommandHandler.spec.ts
+++ b/src/app/application/group/command/modifyGroup/ModifyGroupCommandHandler.spec.ts
@@ -1,31 +1,33 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { ModifyGroupCommandHandler } from './ModifyGroupCommandHandler';
-import {
-  GroupRepository,
-  IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
-import {
-  GroupMemberRepository,
-  IGroupMemberRepository,
-} from '@sight/app/domain/group/IGroupMemberRepository';
-import {
-  IInterestRepository,
-  InterestRepository,
-} from '@sight/app/domain/interest/IInterestRepository';
 import {
   GroupLogger,
   IGroupLogger,
-} from '@sight/app/domain/group/IGroupLogger';
-import { ModifyGroupCommand } from './ModifyGroupCommand';
+} from '@khlug/app/domain/group/IGroupLogger';
+import {
+  GroupMemberRepository,
+  IGroupMemberRepository,
+} from '@khlug/app/domain/group/IGroupMemberRepository';
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@khlug/app/domain/group/IGroupRepository';
 import {
   GroupAccessGrade,
   GroupCategory,
-} from '@sight/app/domain/group/model/constant';
-import { Message } from '@sight/constant/message';
-import { GroupFixture } from '@sight/__test__/fixtures/GroupFixture';
-import { DomainFixture } from '@sight/__test__/fixtures';
+} from '@khlug/app/domain/group/model/constant';
+import {
+  IInterestRepository,
+  InterestRepository,
+} from '@khlug/app/domain/interest/IInterestRepository';
+
+import { DomainFixture } from '@khlug/__test__/fixtures';
+import { GroupFixture } from '@khlug/__test__/fixtures/GroupFixture';
+import { Message } from '@khlug/constant/message';
+
+import { ModifyGroupCommand } from './ModifyGroupCommand';
+import { ModifyGroupCommandHandler } from './ModifyGroupCommandHandler';
 
 describe('ModifyGroupCommandHandler', () => {
   let handler: ModifyGroupCommandHandler;

--- a/src/app/application/group/command/modifyGroup/ModifyGroupCommandHandler.ts
+++ b/src/app/application/group/command/modifyGroup/ModifyGroupCommandHandler.ts
@@ -1,40 +1,40 @@
-import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import {
   ForbiddenException,
   Inject,
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
-import { Transactional } from '@sight/core/persistence/transaction/Transactional';
+import { Transactional } from '@khlug/core/persistence/transaction/Transactional';
 
 import {
   ModifyGroupCommand,
   ModifyGroupParams,
-} from '@sight/app/application/group/command/modifyGroup/ModifyGroupCommand';
-import { ModifyGroupCommandResult } from '@sight/app/application/group/command/modifyGroup/ModifyGroupCommandResult';
+} from '@khlug/app/application/group/command/modifyGroup/ModifyGroupCommand';
+import { ModifyGroupCommandResult } from '@khlug/app/application/group/command/modifyGroup/ModifyGroupCommandResult';
 
-import { Group } from '@sight/app/domain/group/model/Group';
-import {
-  GroupMemberRepository,
-  IGroupMemberRepository,
-} from '@sight/app/domain/group/IGroupMemberRepository';
-import {
-  GroupRepository,
-  IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
-import { GroupCategory } from '@sight/app/domain/group/model/constant';
-import {
-  IInterestRepository,
-  InterestRepository,
-} from '@sight/app/domain/interest/IInterestRepository';
-
-import { Message } from '@sight/constant/message';
 import {
   GroupLogger,
   IGroupLogger,
-} from '@sight/app/domain/group/IGroupLogger';
-import { isDifferentStringArray } from '@sight/util/isDifferentStringArray';
+} from '@khlug/app/domain/group/IGroupLogger';
+import {
+  GroupMemberRepository,
+  IGroupMemberRepository,
+} from '@khlug/app/domain/group/IGroupMemberRepository';
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@khlug/app/domain/group/IGroupRepository';
+import { GroupCategory } from '@khlug/app/domain/group/model/constant';
+import { Group } from '@khlug/app/domain/group/model/Group';
+import {
+  IInterestRepository,
+  InterestRepository,
+} from '@khlug/app/domain/interest/IInterestRepository';
+
+import { Message } from '@khlug/constant/message';
+import { isDifferentStringArray } from '@khlug/util/isDifferentStringArray';
 
 type UpdatedItem =
   | 'category'

--- a/src/app/application/group/command/modifyGroup/ModifyGroupCommandResult.ts
+++ b/src/app/application/group/command/modifyGroup/ModifyGroupCommandResult.ts
@@ -1,4 +1,4 @@
-import { Group } from '@sight/app/domain/group/model/Group';
+import { Group } from '@khlug/app/domain/group/model/Group';
 
 export class ModifyGroupCommandResult {
   constructor(readonly group: Group) {}

--- a/src/app/application/group/command/removeBookmark/RemoveBookmarkCommandHandler.spec.ts
+++ b/src/app/application/group/command/removeBookmark/RemoveBookmarkCommandHandler.spec.ts
@@ -1,20 +1,22 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { RemoveBookmarkCommandHandler } from './RemoveBookmarkCommandHandler';
-import {
-  GroupRepository,
-  IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
+import { SlackSender } from '@khlug/app/domain/adapter/ISlackSender';
 import {
   GroupBookmarkRepository,
   IGroupBookmarkRepository,
-} from '@sight/app/domain/group/IGroupBookmarkRepository';
-import { SlackSender } from '@sight/app/domain/adapter/ISlackSender';
+} from '@khlug/app/domain/group/IGroupBookmarkRepository';
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@khlug/app/domain/group/IGroupRepository';
+
+import { GroupBookmarkFixture } from '@khlug/__test__/fixtures/GroupBookmarkFixture';
+import { GroupFixture } from '@khlug/__test__/fixtures/GroupFixture';
+import { Message } from '@khlug/constant/message';
+
 import { RemoveBookmarkCommand } from './RemoveBookmarkCommand';
-import { Message } from '@sight/constant/message';
-import { GroupFixture } from '@sight/__test__/fixtures/GroupFixture';
-import { GroupBookmarkFixture } from '@sight/__test__/fixtures/GroupBookmarkFixture';
+import { RemoveBookmarkCommandHandler } from './RemoveBookmarkCommandHandler';
 
 describe('RemoveBookmarkCommandHandler', () => {
   let handler: RemoveBookmarkCommandHandler;

--- a/src/app/application/group/command/removeBookmark/RemoveBookmarkCommandHandler.ts
+++ b/src/app/application/group/command/removeBookmark/RemoveBookmarkCommandHandler.ts
@@ -1,31 +1,31 @@
-import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 import {
   Inject,
   NotFoundException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
-import { Transactional } from '@sight/core/persistence/transaction/Transactional';
+import { MessageBuilder } from '@khlug/core/message/MessageBuilder';
+import { Transactional } from '@khlug/core/persistence/transaction/Transactional';
 
-import { RemoveBookmarkCommand } from '@sight/app/application/group/command/removeBookmark/RemoveBookmarkCommand';
+import { RemoveBookmarkCommand } from '@khlug/app/application/group/command/removeBookmark/RemoveBookmarkCommand';
 
-import {
-  GroupBookmarkRepository,
-  IGroupBookmarkRepository,
-} from '@sight/app/domain/group/IGroupBookmarkRepository';
-import {
-  GroupRepository,
-  IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
-
-import { Message } from '@sight/constant/message';
 import {
   ISlackSender,
   SlackSender,
-} from '@sight/app/domain/adapter/ISlackSender';
-import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
-import { Template } from '@sight/constant/template';
-import { MessageBuilder } from '@sight/core/message/MessageBuilder';
+} from '@khlug/app/domain/adapter/ISlackSender';
+import {
+  GroupBookmarkRepository,
+  IGroupBookmarkRepository,
+} from '@khlug/app/domain/group/IGroupBookmarkRepository';
+import {
+  GroupRepository,
+  IGroupRepository,
+} from '@khlug/app/domain/group/IGroupRepository';
+import { SlackMessageCategory } from '@khlug/app/domain/message/model/constant';
+
+import { Message } from '@khlug/constant/message';
+import { Template } from '@khlug/constant/template';
 
 @CommandHandler(RemoveBookmarkCommand)
 export class RemoveBookmarkCommandHandler

--- a/src/app/application/group/eventHandler/GroupStateChangedHandler.ts
+++ b/src/app/application/group/eventHandler/GroupStateChangedHandler.ts
@@ -1,26 +1,26 @@
 import { Inject } from '@nestjs/common';
 import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
 
-import { Transactional } from '@sight/core/persistence/transaction/Transactional';
+import { Transactional } from '@khlug/core/persistence/transaction/Transactional';
 
-import { GroupStateChanged } from '@sight/app/domain/group/event/GroupStateChanged';
-import { GroupState } from '@sight/app/domain/group/model/constant';
-import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
 import {
   ISlackSender,
   SlackSender,
-} from '@sight/app/domain/adapter/ISlackSender';
+} from '@khlug/app/domain/adapter/ISlackSender';
+import { GroupStateChanged } from '@khlug/app/domain/group/event/GroupStateChanged';
 import {
   GroupMemberRepository,
   IGroupMemberRepository,
-} from '@sight/app/domain/group/IGroupMemberRepository';
+} from '@khlug/app/domain/group/IGroupMemberRepository';
 import {
   GroupRepository,
   IGroupRepository,
-} from '@sight/app/domain/group/IGroupRepository';
+} from '@khlug/app/domain/group/IGroupRepository';
+import { GroupState } from '@khlug/app/domain/group/model/constant';
+import { SlackMessageCategory } from '@khlug/app/domain/message/model/constant';
+import { PointGrantService } from '@khlug/app/domain/user/service/PointGrantService';
 
-import { Point } from '@sight/constant/point';
-import { PointGrantService } from '@sight/app/domain/user/service/PointGrantService';
+import { Point } from '@khlug/constant/point';
 
 // TODO[lery]: 그룹 상태 핸들러가 분리되면 그때 제거하기
 @EventsHandler(GroupStateChanged)

--- a/src/app/application/group/query/IGroupQuery.ts
+++ b/src/app/application/group/query/IGroupQuery.ts
@@ -1,6 +1,6 @@
-import { GroupListQueryType } from '@sight/app/application/group/query/listGroup/ListGroupQuery';
-import { GroupListView } from '@sight/app/application/group/query/view/GroupListView';
-import { GroupMemberListView } from '@sight/app/application/group/query/view/GroupMemberListView';
+import { GroupListQueryType } from '@khlug/app/application/group/query/listGroup/ListGroupQuery';
+import { GroupListView } from '@khlug/app/application/group/query/view/GroupListView';
+import { GroupMemberListView } from '@khlug/app/application/group/query/view/GroupMemberListView';
 
 type ListGroupParams = {
   queryType: GroupListQueryType;

--- a/src/app/application/group/query/listGroup/ListGroupQuery.ts
+++ b/src/app/application/group/query/listGroup/ListGroupQuery.ts
@@ -1,6 +1,6 @@
 import { IQuery } from '@nestjs/cqrs';
 
-import { ToUnion } from '@sight/util/types';
+import { ToUnion } from '@khlug/util/types';
 
 export const GroupListQueryType = {
   MY: 'MY',

--- a/src/app/application/group/query/listGroup/ListGroupQueryHandler.spec.ts
+++ b/src/app/application/group/query/listGroup/ListGroupQueryHandler.spec.ts
@@ -4,16 +4,16 @@ import { advanceTo, clear } from 'jest-date-mock';
 import {
   GroupQuery,
   IGroupQuery,
-} from '@sight/app/application/group/query/IGroupQuery';
+} from '@khlug/app/application/group/query/IGroupQuery';
 import {
   GroupListQueryType,
   ListGroupQuery,
-} from '@sight/app/application/group/query/listGroup/ListGroupQuery';
-import { ListGroupQueryHandler } from '@sight/app/application/group/query/listGroup/ListGroupQueryHandler';
-import { ListGroupQueryResult } from '@sight/app/application/group/query/listGroup/ListGroupQueryResult';
-import { GroupListView } from '@sight/app/application/group/query/view/GroupListView';
+} from '@khlug/app/application/group/query/listGroup/ListGroupQuery';
+import { ListGroupQueryHandler } from '@khlug/app/application/group/query/listGroup/ListGroupQueryHandler';
+import { ListGroupQueryResult } from '@khlug/app/application/group/query/listGroup/ListGroupQueryResult';
+import { GroupListView } from '@khlug/app/application/group/query/view/GroupListView';
 
-import { ViewFixture } from '@sight/__test__/fixtures';
+import { ViewFixture } from '@khlug/__test__/fixtures';
 
 describe('ListGroupQueryHandler', () => {
   let handler: ListGroupQueryHandler;

--- a/src/app/application/group/query/listGroup/ListGroupQueryHandler.ts
+++ b/src/app/application/group/query/listGroup/ListGroupQueryHandler.ts
@@ -4,9 +4,9 @@ import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import {
   GroupQuery,
   IGroupQuery,
-} from '@sight/app/application/group/query/IGroupQuery';
-import { ListGroupQuery } from '@sight/app/application/group/query/listGroup/ListGroupQuery';
-import { ListGroupQueryResult } from '@sight/app/application/group/query/listGroup/ListGroupQueryResult';
+} from '@khlug/app/application/group/query/IGroupQuery';
+import { ListGroupQuery } from '@khlug/app/application/group/query/listGroup/ListGroupQuery';
+import { ListGroupQueryResult } from '@khlug/app/application/group/query/listGroup/ListGroupQueryResult';
 
 @QueryHandler(ListGroupQuery)
 export class ListGroupQueryHandler

--- a/src/app/application/group/query/listGroup/ListGroupQueryResult.ts
+++ b/src/app/application/group/query/listGroup/ListGroupQueryResult.ts
@@ -1,6 +1,6 @@
 import { IQueryResult } from '@nestjs/cqrs';
 
-import { GroupListView } from '@sight/app/application/group/query/view/GroupListView';
+import { GroupListView } from '@khlug/app/application/group/query/view/GroupListView';
 
 export class ListGroupQueryResult implements IQueryResult {
   constructor(readonly listView: GroupListView) {}

--- a/src/app/application/group/query/listGroupMember/ListGroupMemberQueryHandler.spec.ts
+++ b/src/app/application/group/query/listGroupMember/ListGroupMemberQueryHandler.spec.ts
@@ -4,13 +4,13 @@ import { advanceTo, clear } from 'jest-date-mock';
 import {
   GroupQuery,
   IGroupQuery,
-} from '@sight/app/application/group/query/IGroupQuery';
-import { ListGroupMemberQuery } from '@sight/app/application/group/query/listGroupMember/ListGroupMemberQuery';
-import { ListGroupMemberQueryHandler } from '@sight/app/application/group/query/listGroupMember/ListGroupMemberQueryHandler';
-import { ListGroupMemberQueryResult } from '@sight/app/application/group/query/listGroupMember/ListGroupMemberQueryResult';
-import { GroupMemberListView } from '@sight/app/application/group/query/view/GroupMemberListView';
+} from '@khlug/app/application/group/query/IGroupQuery';
+import { ListGroupMemberQuery } from '@khlug/app/application/group/query/listGroupMember/ListGroupMemberQuery';
+import { ListGroupMemberQueryHandler } from '@khlug/app/application/group/query/listGroupMember/ListGroupMemberQueryHandler';
+import { ListGroupMemberQueryResult } from '@khlug/app/application/group/query/listGroupMember/ListGroupMemberQueryResult';
+import { GroupMemberListView } from '@khlug/app/application/group/query/view/GroupMemberListView';
 
-import { ViewFixture } from '@sight/__test__/fixtures';
+import { ViewFixture } from '@khlug/__test__/fixtures';
 
 describe('ListGroupMemberQueryHandler', () => {
   let handler: ListGroupMemberQueryHandler;

--- a/src/app/application/group/query/listGroupMember/ListGroupMemberQueryHandler.ts
+++ b/src/app/application/group/query/listGroupMember/ListGroupMemberQueryHandler.ts
@@ -4,9 +4,9 @@ import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import {
   GroupQuery,
   IGroupQuery,
-} from '@sight/app/application/group/query/IGroupQuery';
-import { ListGroupMemberQuery } from '@sight/app/application/group/query/listGroupMember/ListGroupMemberQuery';
-import { ListGroupMemberQueryResult } from '@sight/app/application/group/query/listGroupMember/ListGroupMemberQueryResult';
+} from '@khlug/app/application/group/query/IGroupQuery';
+import { ListGroupMemberQuery } from '@khlug/app/application/group/query/listGroupMember/ListGroupMemberQuery';
+import { ListGroupMemberQueryResult } from '@khlug/app/application/group/query/listGroupMember/ListGroupMemberQueryResult';
 
 @QueryHandler(ListGroupMemberQuery)
 export class ListGroupMemberQueryHandler

--- a/src/app/application/group/query/listGroupMember/ListGroupMemberQueryResult.ts
+++ b/src/app/application/group/query/listGroupMember/ListGroupMemberQueryResult.ts
@@ -1,6 +1,6 @@
 import { IQueryResult } from '@nestjs/cqrs';
 
-import { GroupMemberListView } from '@sight/app/application/group/query/view/GroupMemberListView';
+import { GroupMemberListView } from '@khlug/app/application/group/query/view/GroupMemberListView';
 
 export class ListGroupMemberQueryResult implements IQueryResult {
   constructor(readonly listView: GroupMemberListView) {}

--- a/src/app/application/group/query/view/GroupListView.ts
+++ b/src/app/application/group/query/view/GroupListView.ts
@@ -1,4 +1,4 @@
-import { GroupView } from '@sight/app/application/group/query/view/GroupView';
+import { GroupView } from '@khlug/app/application/group/query/view/GroupView';
 
 export interface GroupListView {
   count: number;

--- a/src/app/application/group/query/view/GroupMemberListView.ts
+++ b/src/app/application/group/query/view/GroupMemberListView.ts
@@ -1,4 +1,4 @@
-import { GroupMemberView } from '@sight/app/application/group/query/view/GroupMemberView';
+import { GroupMemberView } from '@khlug/app/application/group/query/view/GroupMemberView';
 
 export interface GroupMemberListView {
   count: number;

--- a/src/app/application/group/query/view/GroupView.ts
+++ b/src/app/application/group/query/view/GroupView.ts
@@ -1,7 +1,7 @@
 import {
   GroupCategory,
   GroupState,
-} from '@sight/app/domain/group/model/constant';
+} from '@khlug/app/domain/group/model/constant';
 
 export interface GroupView {
   id: string;

--- a/src/app/application/interest/query/IInterestQuery.ts
+++ b/src/app/application/interest/query/IInterestQuery.ts
@@ -1,4 +1,4 @@
-import { InterestListView } from '@sight/app/application/interest/query/view/InterestListView';
+import { InterestListView } from '@khlug/app/application/interest/query/view/InterestListView';
 
 export const InterestQuery = Symbol('InterestQuery');
 

--- a/src/app/application/interest/query/listInterest/ListInterestQueryHandler.spec.ts
+++ b/src/app/application/interest/query/listInterest/ListInterestQueryHandler.spec.ts
@@ -1,14 +1,14 @@
 import { Test } from '@nestjs/testing';
 
-import { ListInterestQueryHandler } from '@sight/app/application/interest/query/listInterest/ListInterestQueryHandler';
-import { ListInterestQueryResult } from '@sight/app/application/interest/query/listInterest/ListInterestQueryResult';
-import { InterestListView } from '@sight/app/application/interest/query/view/InterestListView';
 import {
   IInterestQuery,
   InterestQuery,
-} from '@sight/app/application/interest/query/IInterestQuery';
+} from '@khlug/app/application/interest/query/IInterestQuery';
+import { ListInterestQueryHandler } from '@khlug/app/application/interest/query/listInterest/ListInterestQueryHandler';
+import { ListInterestQueryResult } from '@khlug/app/application/interest/query/listInterest/ListInterestQueryResult';
+import { InterestListView } from '@khlug/app/application/interest/query/view/InterestListView';
 
-import { ViewFixture } from '@sight/__test__/fixtures';
+import { ViewFixture } from '@khlug/__test__/fixtures';
 
 describe('ListInterestQueryHandler', () => {
   let listInterestQueryHandler: ListInterestQueryHandler;

--- a/src/app/application/interest/query/listInterest/ListInterestQueryHandler.ts
+++ b/src/app/application/interest/query/listInterest/ListInterestQueryHandler.ts
@@ -1,12 +1,12 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 
 import {
   IInterestQuery,
   InterestQuery,
-} from '@sight/app/application/interest/query/IInterestQuery';
-import { ListInterestQuery } from '@sight/app/application/interest/query/listInterest/ListInterestQuery';
-import { ListInterestQueryResult } from '@sight/app/application/interest/query/listInterest/ListInterestQueryResult';
+} from '@khlug/app/application/interest/query/IInterestQuery';
+import { ListInterestQuery } from '@khlug/app/application/interest/query/listInterest/ListInterestQuery';
+import { ListInterestQueryResult } from '@khlug/app/application/interest/query/listInterest/ListInterestQueryResult';
 
 @Injectable()
 @QueryHandler(ListInterestQuery)

--- a/src/app/application/interest/query/listInterest/ListInterestQueryResult.ts
+++ b/src/app/application/interest/query/listInterest/ListInterestQueryResult.ts
@@ -1,6 +1,6 @@
 import { IQueryResult } from '@nestjs/cqrs';
 
-import { InterestListView } from '@sight/app/application/interest/query/view/InterestListView';
+import { InterestListView } from '@khlug/app/application/interest/query/view/InterestListView';
 
 export class ListInterestQueryResult implements IQueryResult {
   constructor(readonly view: InterestListView) {}

--- a/src/app/application/interest/query/view/InterestListView.ts
+++ b/src/app/application/interest/query/view/InterestListView.ts
@@ -1,4 +1,4 @@
-import { InterestView } from '@sight/app/application/interest/query/view/InterestView';
+import { InterestView } from '@khlug/app/application/interest/query/view/InterestView';
 
 export interface InterestListView {
   count: number;

--- a/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandHandler.spec.ts
+++ b/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandHandler.spec.ts
@@ -1,20 +1,20 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { UpdateUnitedUserCommand } from '@sight/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommand';
-import { UpdateUnitedUserCommandHandler } from '@sight/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandHandler';
+import { UpdateUnitedUserCommand } from '@khlug/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommand';
+import { UpdateUnitedUserCommandHandler } from '@khlug/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandHandler';
 
-import { UserState } from '@sight/app/domain/user/model/constant';
-import { User } from '@sight/app/domain/user/model/User';
 import {
   IUserRepository,
   UserRepository,
-} from '@sight/app/domain/user/IUserRepository';
+} from '@khlug/app/domain/user/IUserRepository';
+import { UserState } from '@khlug/app/domain/user/model/constant';
+import { User } from '@khlug/app/domain/user/model/User';
 
-import { generateUser } from '@sight/__test__/fixtures/domain';
-import { Message } from '@sight/constant/message';
+import { generateUser } from '@khlug/__test__/fixtures/domain';
+import { Message } from '@khlug/constant/message';
 
-jest.mock('@sight/core/persistence/transaction/Transactional', () => ({
+jest.mock('@khlug/core/persistence/transaction/Transactional', () => ({
   Transactional: () => () => {},
 }));
 

--- a/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandHandler.ts
+++ b/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandHandler.ts
@@ -1,17 +1,17 @@
 import { Inject, NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
-import { Transactional } from '@sight/core/persistence/transaction/Transactional';
+import { Transactional } from '@khlug/core/persistence/transaction/Transactional';
 
-import { UpdateUnitedUserCommand } from '@sight/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommand';
-import { UpdateUnitedUserCommandResult } from '@sight/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandResult';
+import { UpdateUnitedUserCommand } from '@khlug/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommand';
+import { UpdateUnitedUserCommandResult } from '@khlug/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandResult';
 
 import {
   IUserRepository,
   UserRepository,
-} from '@sight/app/domain/user/IUserRepository';
+} from '@khlug/app/domain/user/IUserRepository';
 
-import { Message } from '@sight/constant/message';
+import { Message } from '@khlug/constant/message';
 
 @CommandHandler(UpdateUnitedUserCommand)
 export class UpdateUnitedUserCommandHandler

--- a/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandResult.ts
+++ b/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandResult.ts
@@ -1,4 +1,4 @@
-import { User } from '@sight/app/domain/user/model/User';
+import { User } from '@khlug/app/domain/user/model/User';
 
 export class UpdateUnitedUserCommandResult {
   constructor(readonly user: User) {}

--- a/src/app/application/user/command/updateUser/UpdateUserCommandHandler.spec.ts
+++ b/src/app/application/user/command/updateUser/UpdateUserCommandHandler.spec.ts
@@ -1,38 +1,38 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { UpdateUserCommand } from '@sight/app/application/user/command/updateUser/UpdateUserCommand';
-import { UpdateUserCommandHandler } from '@sight/app/application/user/command/updateUser/UpdateUserCommandHandler';
-import { UpdateUserCommandResult } from '@sight/app/application/user/command/updateUser/UpdateUserCommandResult';
+import { UpdateUserCommand } from '@khlug/app/application/user/command/updateUser/UpdateUserCommand';
+import { UpdateUserCommandHandler } from '@khlug/app/application/user/command/updateUser/UpdateUserCommandHandler';
+import { UpdateUserCommandResult } from '@khlug/app/application/user/command/updateUser/UpdateUserCommandResult';
 
-import { Interest } from '@sight/app/domain/interest/model/Interest';
-import { UserInterestFactory } from '@sight/app/domain/interest/UserInterestFactory';
-import { UserState } from '@sight/app/domain/user/model/constant';
-import { User } from '@sight/app/domain/user/model/User';
 import {
   ISlackSender,
   SlackSender,
-} from '@sight/app/domain/adapter/ISlackSender';
+} from '@khlug/app/domain/adapter/ISlackSender';
 import {
   IInterestRepository,
   InterestRepository,
-} from '@sight/app/domain/interest/IInterestRepository';
+} from '@khlug/app/domain/interest/IInterestRepository';
 import {
   IUserInterestRepository,
   UserInterestRepository,
-} from '@sight/app/domain/interest/IUserInterestRepository';
+} from '@khlug/app/domain/interest/IUserInterestRepository';
+import { Interest } from '@khlug/app/domain/interest/model/Interest';
+import { UserInterestFactory } from '@khlug/app/domain/interest/UserInterestFactory';
 import {
   IUserRepository,
   UserRepository,
-} from '@sight/app/domain/user/IUserRepository';
+} from '@khlug/app/domain/user/IUserRepository';
+import { UserState } from '@khlug/app/domain/user/model/constant';
+import { User } from '@khlug/app/domain/user/model/User';
 
-import { Message } from '@sight/constant/message';
 import {
   generateInterest,
   generateUser,
-} from '@sight/__test__/fixtures/domain';
+} from '@khlug/__test__/fixtures/domain';
+import { Message } from '@khlug/constant/message';
 
-jest.mock('@sight/core/persistence/transaction/Transactional', () => ({
+jest.mock('@khlug/core/persistence/transaction/Transactional', () => ({
   Transactional: () => () => {},
 }));
 

--- a/src/app/application/user/command/updateUser/UpdateUserCommandHandler.ts
+++ b/src/app/application/user/command/updateUser/UpdateUserCommandHandler.ts
@@ -1,27 +1,27 @@
 import { Inject, NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
-import { Transactional } from '@sight/core/persistence/transaction/Transactional';
+import { Transactional } from '@khlug/core/persistence/transaction/Transactional';
 
-import { UpdateUserCommand } from '@sight/app/application/user/command/updateUser/UpdateUserCommand';
-import { UpdateUserCommandResult } from '@sight/app/application/user/command/updateUser/UpdateUserCommandResult';
+import { UpdateUserCommand } from '@khlug/app/application/user/command/updateUser/UpdateUserCommand';
+import { UpdateUserCommandResult } from '@khlug/app/application/user/command/updateUser/UpdateUserCommandResult';
 
-import { UserInterest } from '@sight/app/domain/interest/model/UserInterest';
-import { UserInterestFactory } from '@sight/app/domain/interest/UserInterestFactory';
 import {
   IInterestRepository,
   InterestRepository,
-} from '@sight/app/domain/interest/IInterestRepository';
+} from '@khlug/app/domain/interest/IInterestRepository';
 import {
   IUserInterestRepository,
   UserInterestRepository,
-} from '@sight/app/domain/interest/IUserInterestRepository';
+} from '@khlug/app/domain/interest/IUserInterestRepository';
+import { UserInterest } from '@khlug/app/domain/interest/model/UserInterest';
+import { UserInterestFactory } from '@khlug/app/domain/interest/UserInterestFactory';
 import {
   IUserRepository,
   UserRepository,
-} from '@sight/app/domain/user/IUserRepository';
+} from '@khlug/app/domain/user/IUserRepository';
 
-import { Message } from '@sight/constant/message';
+import { Message } from '@khlug/constant/message';
 
 @CommandHandler(UpdateUserCommand)
 export class UpdateUserCommandHandler

--- a/src/app/application/user/command/updateUser/UpdateUserCommandResult.ts
+++ b/src/app/application/user/command/updateUser/UpdateUserCommandResult.ts
@@ -1,4 +1,4 @@
-import { User } from '@sight/app/domain/user/model/User';
+import { User } from '@khlug/app/domain/user/model/User';
 
 export class UpdateUserCommandResult {
   constructor(readonly user: User) {}

--- a/src/app/application/user/eventHandler/UserProfileUpdatedHandler.spec.ts
+++ b/src/app/application/user/eventHandler/UserProfileUpdatedHandler.spec.ts
@@ -1,16 +1,16 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { UserProfileUpdatedHandler } from '@sight/app/application/user/eventHandler/UserProfileUpdatedHandler';
+import { UserProfileUpdatedHandler } from '@khlug/app/application/user/eventHandler/UserProfileUpdatedHandler';
 
-import { UserProfileUpdated } from '@sight/app/domain/user/event/UserProfileUpdated';
-import { User } from '@sight/app/domain/user/model/User';
 import {
   ISlackSender,
   SlackSender,
-} from '@sight/app/domain/adapter/ISlackSender';
+} from '@khlug/app/domain/adapter/ISlackSender';
+import { UserProfileUpdated } from '@khlug/app/domain/user/event/UserProfileUpdated';
+import { User } from '@khlug/app/domain/user/model/User';
 
-import { generateUser } from '@sight/__test__/fixtures/domain';
+import { generateUser } from '@khlug/__test__/fixtures/domain';
 
 describe('UserProfileUpdatedHandler', () => {
   let handler: UserProfileUpdatedHandler;

--- a/src/app/application/user/eventHandler/UserProfileUpdatedHandler.ts
+++ b/src/app/application/user/eventHandler/UserProfileUpdatedHandler.ts
@@ -1,12 +1,12 @@
 import { Inject } from '@nestjs/common';
 import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
 
-import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
-import { UserProfileUpdated } from '@sight/app/domain/user/event/UserProfileUpdated';
 import {
   ISlackSender,
   SlackSender,
-} from '@sight/app/domain/adapter/ISlackSender';
+} from '@khlug/app/domain/adapter/ISlackSender';
+import { SlackMessageCategory } from '@khlug/app/domain/message/model/constant';
+import { UserProfileUpdated } from '@khlug/app/domain/user/event/UserProfileUpdated';
 
 @EventsHandler(UserProfileUpdated)
 export class UserProfileUpdatedHandler

--- a/src/app/application/user/query/IUserQuery.ts
+++ b/src/app/application/user/query/IUserQuery.ts
@@ -1,6 +1,6 @@
-import { UserListView } from '@sight/app/application/user/query/view/UserListView';
+import { UserListView } from '@khlug/app/application/user/query/view/UserListView';
 
-import { UserState } from '@sight/app/domain/user/model/constant';
+import { UserState } from '@khlug/app/domain/user/model/constant';
 
 export type ListUserParams = {
   state: UserState | null;

--- a/src/app/application/user/query/listUser/ListUserQuery.ts
+++ b/src/app/application/user/query/listUser/ListUserQuery.ts
@@ -1,6 +1,6 @@
 import { IQuery } from '@nestjs/cqrs';
 
-import { UserState } from '@sight/app/domain/user/model/constant';
+import { UserState } from '@khlug/app/domain/user/model/constant';
 
 export class ListUserQuery implements IQuery {
   constructor(

--- a/src/app/application/user/query/listUser/ListUserQueryHandler.spec.ts
+++ b/src/app/application/user/query/listUser/ListUserQueryHandler.spec.ts
@@ -1,17 +1,17 @@
 import { Test } from '@nestjs/testing';
 
-import { ListUserQuery } from '@sight/app/application/user/query/listUser/ListUserQuery';
-import { ListUserQueryHandler } from '@sight/app/application/user/query/listUser/ListUserQueryHandler';
-import { ListUserQueryResult } from '@sight/app/application/user/query/listUser/ListUserQueryResult';
-import { UserListView } from '@sight/app/application/user/query/view/UserListView';
 import {
   IUserQuery,
   UserQuery,
-} from '@sight/app/application/user/query/IUserQuery';
+} from '@khlug/app/application/user/query/IUserQuery';
+import { ListUserQuery } from '@khlug/app/application/user/query/listUser/ListUserQuery';
+import { ListUserQueryHandler } from '@khlug/app/application/user/query/listUser/ListUserQueryHandler';
+import { ListUserQueryResult } from '@khlug/app/application/user/query/listUser/ListUserQueryResult';
+import { UserListView } from '@khlug/app/application/user/query/view/UserListView';
 
-import { UserState } from '@sight/app/domain/user/model/constant';
+import { UserState } from '@khlug/app/domain/user/model/constant';
 
-import { ViewFixture } from '@sight/__test__/fixtures';
+import { ViewFixture } from '@khlug/__test__/fixtures';
 
 describe('ListUserQueryHandler', () => {
   let listUserQueryHandler: ListUserQueryHandler;

--- a/src/app/application/user/query/listUser/ListUserQueryHandler.ts
+++ b/src/app/application/user/query/listUser/ListUserQueryHandler.ts
@@ -4,9 +4,9 @@ import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import {
   IUserQuery,
   UserQuery,
-} from '@sight/app/application/user/query/IUserQuery';
-import { ListUserQuery } from '@sight/app/application/user/query/listUser/ListUserQuery';
-import { ListUserQueryResult } from '@sight/app/application/user/query/listUser/ListUserQueryResult';
+} from '@khlug/app/application/user/query/IUserQuery';
+import { ListUserQuery } from '@khlug/app/application/user/query/listUser/ListUserQuery';
+import { ListUserQueryResult } from '@khlug/app/application/user/query/listUser/ListUserQueryResult';
 
 @Injectable()
 @QueryHandler(ListUserQuery)

--- a/src/app/application/user/query/listUser/ListUserQueryResult.ts
+++ b/src/app/application/user/query/listUser/ListUserQueryResult.ts
@@ -1,6 +1,6 @@
 import { IQueryResult } from '@nestjs/cqrs';
 
-import { UserListView } from '@sight/app/application/user/query/view/UserListView';
+import { UserListView } from '@khlug/app/application/user/query/view/UserListView';
 
 export class ListUserQueryResult implements IQueryResult {
   constructor(readonly view: UserListView) {}

--- a/src/app/application/user/query/view/UserListView.ts
+++ b/src/app/application/user/query/view/UserListView.ts
@@ -1,4 +1,4 @@
-import { UserView } from '@sight/app/application/user/query/view/UserView';
+import { UserView } from '@khlug/app/application/user/query/view/UserView';
 
 export interface UserListView {
   count: number;

--- a/src/app/application/user/query/view/UserView.ts
+++ b/src/app/application/user/query/view/UserView.ts
@@ -1,4 +1,4 @@
-import { UserState } from '@sight/app/domain/user/model/constant';
+import { UserState } from '@khlug/app/domain/user/model/constant';
 
 export interface ProfileView {
   name: string;

--- a/src/app/domain/adapter/ISlackSender.ts
+++ b/src/app/domain/adapter/ISlackSender.ts
@@ -1,4 +1,4 @@
-import { SlackMessageCategory } from '@sight/app/domain/message/model/constant';
+import { SlackMessageCategory } from '@khlug/app/domain/message/model/constant';
 
 export type SlackSendParams = {
   sourceUserId?: string;

--- a/src/app/domain/group/GroupBookmarkFactory.spec.ts
+++ b/src/app/domain/group/GroupBookmarkFactory.spec.ts
@@ -1,8 +1,8 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { GroupBookmarkFactory } from '@sight/app/domain/group/GroupBookmarkFactory';
-import { GroupBookmark } from '@sight/app/domain/group/model/GroupBookmark';
+import { GroupBookmarkFactory } from '@khlug/app/domain/group/GroupBookmarkFactory';
+import { GroupBookmark } from '@khlug/app/domain/group/model/GroupBookmark';
 
 describe('GroupBookmarkFactory', () => {
   let groupBookmarkFactory: GroupBookmarkFactory;

--- a/src/app/domain/group/GroupBookmarkFactory.ts
+++ b/src/app/domain/group/GroupBookmarkFactory.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import {
   GroupBookmark,
   GroupBookmarkConstructorParams,
-} from '@sight/app/domain/group/model/GroupBookmark';
+} from '@khlug/app/domain/group/model/GroupBookmark';
 
 type GroupBookmarkCreateParams = Omit<
   GroupBookmarkConstructorParams,

--- a/src/app/domain/group/GroupFactory.spec.ts
+++ b/src/app/domain/group/GroupFactory.spec.ts
@@ -1,13 +1,13 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { GroupFactory } from '@sight/app/domain/group/GroupFactory';
-import { Group } from '@sight/app/domain/group/model/Group';
+import { GroupFactory } from '@khlug/app/domain/group/GroupFactory';
 import {
   GroupAccessGrade,
   GroupCategory,
   GroupState,
-} from '@sight/app/domain/group/model/constant';
+} from '@khlug/app/domain/group/model/constant';
+import { Group } from '@khlug/app/domain/group/model/Group';
 
 describe('GroupFactory', () => {
   let groupFactory: GroupFactory;

--- a/src/app/domain/group/GroupFactory.ts
+++ b/src/app/domain/group/GroupFactory.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import {
   Group,
   GroupConstructorParams,
-} from '@sight/app/domain/group/model/Group';
+} from '@khlug/app/domain/group/model/Group';
 
 type GroupCreateParams = Omit<
   GroupConstructorParams,

--- a/src/app/domain/group/GroupLogFactory.spec.ts
+++ b/src/app/domain/group/GroupLogFactory.spec.ts
@@ -1,8 +1,8 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { GroupLogFactory } from '@sight/app/domain/group/GroupLogFactory';
-import { GroupLog } from '@sight/app/domain/group/model/GroupLog';
+import { GroupLogFactory } from '@khlug/app/domain/group/GroupLogFactory';
+import { GroupLog } from '@khlug/app/domain/group/model/GroupLog';
 
 describe('GroupLogFactory', () => {
   let groupLogFactory: GroupLogFactory;

--- a/src/app/domain/group/GroupLogFactory.ts
+++ b/src/app/domain/group/GroupLogFactory.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import {
   GroupLog,
   GroupLogConstructorParams,
-} from '@sight/app/domain/group/model/GroupLog';
+} from '@khlug/app/domain/group/model/GroupLog';
 
 type GroupLogCreateParams = Omit<GroupLogConstructorParams, 'createdAt'>;
 type GroupLogReconstituteParams = GroupLogConstructorParams;

--- a/src/app/domain/group/GroupMemberFactory.spec.ts
+++ b/src/app/domain/group/GroupMemberFactory.spec.ts
@@ -1,8 +1,8 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { GroupMemberFactory } from '@sight/app/domain/group/GroupMemberFactory';
-import { GroupMember } from '@sight/app/domain/group/model/GroupMember';
+import { GroupMemberFactory } from '@khlug/app/domain/group/GroupMemberFactory';
+import { GroupMember } from '@khlug/app/domain/group/model/GroupMember';
 
 describe('GroupMemberFactory', () => {
   let groupMemberFactory: GroupMemberFactory;

--- a/src/app/domain/group/GroupMemberFactory.ts
+++ b/src/app/domain/group/GroupMemberFactory.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import {
   GroupMember,
   GroupMemberConstructorParams,
-} from '@sight/app/domain/group/model/GroupMember';
+} from '@khlug/app/domain/group/model/GroupMember';
 
 type GroupMemberCreateParams = Omit<GroupMemberConstructorParams, 'createdAt'>;
 type GroupMemberReconstituteParams = GroupMemberConstructorParams;

--- a/src/app/domain/group/IGroupBookmarkRepository.ts
+++ b/src/app/domain/group/IGroupBookmarkRepository.ts
@@ -1,6 +1,6 @@
-import { IGenericRepository } from '@sight/core/persistence/IGenericRepository';
+import { IGenericRepository } from '@khlug/core/persistence/IGenericRepository';
 
-import { GroupBookmark } from '@sight/app/domain/group/model/GroupBookmark';
+import { GroupBookmark } from '@khlug/app/domain/group/model/GroupBookmark';
 
 export const GroupBookmarkRepository = Symbol('GroupBookmarkRepository');
 

--- a/src/app/domain/group/IGroupLogRepository.ts
+++ b/src/app/domain/group/IGroupLogRepository.ts
@@ -1,6 +1,6 @@
-import { IGenericRepository } from '@sight/core/persistence/IGenericRepository';
+import { IGenericRepository } from '@khlug/core/persistence/IGenericRepository';
 
-import { GroupLog } from '@sight/app/domain/group/model/GroupLog';
+import { GroupLog } from '@khlug/app/domain/group/model/GroupLog';
 
 export const GroupLogRepository = Symbol('GroupLogRepository');
 

--- a/src/app/domain/group/IGroupMemberRepository.ts
+++ b/src/app/domain/group/IGroupMemberRepository.ts
@@ -1,6 +1,6 @@
-import { IGenericRepository } from '@sight/core/persistence/IGenericRepository';
+import { IGenericRepository } from '@khlug/core/persistence/IGenericRepository';
 
-import { GroupMember } from '@sight/app/domain/group/model/GroupMember';
+import { GroupMember } from '@khlug/app/domain/group/model/GroupMember';
 
 export const GroupMemberRepository = Symbol('GroupMemberRepository');
 

--- a/src/app/domain/group/IGroupRepository.ts
+++ b/src/app/domain/group/IGroupRepository.ts
@@ -1,6 +1,6 @@
-import { IGenericRepository } from '@sight/core/persistence/IGenericRepository';
+import { IGenericRepository } from '@khlug/core/persistence/IGenericRepository';
 
-import { Group } from '@sight/app/domain/group/model/Group';
+import { Group } from '@khlug/app/domain/group/model/Group';
 
 export const GroupRepository = Symbol('GroupRepository');
 

--- a/src/app/domain/group/event/GroupStateChanged.ts
+++ b/src/app/domain/group/event/GroupStateChanged.ts
@@ -1,4 +1,4 @@
-import { GroupState } from '@sight/app/domain/group/model/constant';
+import { GroupState } from '@khlug/app/domain/group/model/constant';
 
 export class GroupStateChanged {
   constructor(

--- a/src/app/domain/group/model/Group.spec.ts
+++ b/src/app/domain/group/model/Group.spec.ts
@@ -1,9 +1,9 @@
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { GroupState } from '@sight/app/domain/group/model/constant';
+import { GroupState } from '@khlug/app/domain/group/model/constant';
 
-import { Message } from '@sight/constant/message';
-import { GroupFixture } from '@sight/__test__/fixtures/GroupFixture';
+import { GroupFixture } from '@khlug/__test__/fixtures/GroupFixture';
+import { Message } from '@khlug/constant/message';
 
 describe('Group', () => {
   beforeAll(() => {

--- a/src/app/domain/group/model/Group.ts
+++ b/src/app/domain/group/model/Group.ts
@@ -7,8 +7,9 @@ import {
   GroupCategory,
   GroupState,
   PRACTICE_GROUP_ID,
-} from '@sight/app/domain/group/model/constant';
-import { Message } from '@sight/constant/message';
+} from '@khlug/app/domain/group/model/constant';
+
+import { Message } from '@khlug/constant/message';
 
 export type GroupConstructorParams = {
   id: string;

--- a/src/app/domain/group/model/GroupCard.ts
+++ b/src/app/domain/group/model/GroupCard.ts
@@ -1,6 +1,6 @@
 import { AggregateRoot } from '@nestjs/cqrs';
 
-import { GroupCardState } from '@sight/app/domain/group/model/constant';
+import { GroupCardState } from '@khlug/app/domain/group/model/constant';
 
 export type GroupCardConstructorParams = {
   id: string;

--- a/src/app/domain/group/model/GroupRecord.ts
+++ b/src/app/domain/group/model/GroupRecord.ts
@@ -1,6 +1,6 @@
 import { AggregateRoot } from '@nestjs/cqrs';
 
-import { GroupRecordState } from '@sight/app/domain/group/model/constant';
+import { GroupRecordState } from '@khlug/app/domain/group/model/constant';
 
 export type GroupRecordConstructorParams = {
   id: string;

--- a/src/app/domain/interest/IInterestRepository.ts
+++ b/src/app/domain/interest/IInterestRepository.ts
@@ -1,6 +1,6 @@
-import { IGenericRepository } from '@sight/core/persistence/IGenericRepository';
+import { IGenericRepository } from '@khlug/core/persistence/IGenericRepository';
 
-import { Interest } from '@sight/app/domain/interest/model/Interest';
+import { Interest } from '@khlug/app/domain/interest/model/Interest';
 
 export const InterestRepository = Symbol('InterestRepository');
 

--- a/src/app/domain/interest/IUserInterestRepository.ts
+++ b/src/app/domain/interest/IUserInterestRepository.ts
@@ -1,6 +1,6 @@
-import { IGenericRepository } from '@sight/core/persistence/IGenericRepository';
+import { IGenericRepository } from '@khlug/core/persistence/IGenericRepository';
 
-import { UserInterest } from '@sight/app/domain/interest/model/UserInterest';
+import { UserInterest } from '@khlug/app/domain/interest/model/UserInterest';
 
 export const UserInterestRepository = Symbol('UserInterestRepository');
 

--- a/src/app/domain/interest/UserInterestFactory.spec.ts
+++ b/src/app/domain/interest/UserInterestFactory.spec.ts
@@ -1,8 +1,8 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { UserInterest } from '@sight/app/domain/interest/model/UserInterest';
-import { UserInterestFactory } from '@sight/app/domain/interest/UserInterestFactory';
+import { UserInterest } from '@khlug/app/domain/interest/model/UserInterest';
+import { UserInterestFactory } from '@khlug/app/domain/interest/UserInterestFactory';
 
 describe('UserInterestFactory', () => {
   let userInterestFactory: UserInterestFactory;

--- a/src/app/domain/interest/UserInterestFactory.ts
+++ b/src/app/domain/interest/UserInterestFactory.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import {
   UserInterest,
   UserInterestConstructorParams,
-} from '@sight/app/domain/interest/model/UserInterest';
+} from '@khlug/app/domain/interest/model/UserInterest';
 
 type UserInterestCreateParams = Omit<
   UserInterestConstructorParams,

--- a/src/app/domain/seminar/model/Seminar.ts
+++ b/src/app/domain/seminar/model/Seminar.ts
@@ -3,7 +3,7 @@ import { AggregateRoot } from '@nestjs/cqrs';
 import {
   SeminarSemester,
   SeminarState,
-} from '@sight/app/domain/seminar/model/constant';
+} from '@khlug/app/domain/seminar/model/constant';
 
 export type SeminarConstructorParams = {
   id: string;

--- a/src/app/domain/user/IPointHistoryRepository.ts
+++ b/src/app/domain/user/IPointHistoryRepository.ts
@@ -1,6 +1,6 @@
-import { IGenericRepository } from '@sight/core/persistence/IGenericRepository';
+import { IGenericRepository } from '@khlug/core/persistence/IGenericRepository';
 
-import { PointHistory } from '@sight/app/domain/user/model/PointHistory';
+import { PointHistory } from '@khlug/app/domain/user/model/PointHistory';
 
 export const PointHistoryRepository = Symbol('PointHistoryRepository');
 

--- a/src/app/domain/user/IUserRepository.ts
+++ b/src/app/domain/user/IUserRepository.ts
@@ -1,6 +1,6 @@
-import { IGenericRepository } from '@sight/core/persistence/IGenericRepository';
+import { IGenericRepository } from '@khlug/core/persistence/IGenericRepository';
 
-import { User } from '@sight/app/domain/user/model/User';
+import { User } from '@khlug/app/domain/user/model/User';
 
 export const UserRepository = Symbol('UserRepository');
 

--- a/src/app/domain/user/PointHistoryFactory.spec.ts
+++ b/src/app/domain/user/PointHistoryFactory.spec.ts
@@ -1,8 +1,8 @@
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { PointHistory } from '@sight/app/domain/user/model/PointHistory';
-import { PointHistoryFactory } from '@sight/app/domain/user/PointHistoryFactory';
+import { PointHistory } from '@khlug/app/domain/user/model/PointHistory';
+import { PointHistoryFactory } from '@khlug/app/domain/user/PointHistoryFactory';
 
 describe('PointHistoryFactory', () => {
   let pointHistoryFactory: PointHistoryFactory;

--- a/src/app/domain/user/PointHistoryFactory.ts
+++ b/src/app/domain/user/PointHistoryFactory.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import {
   PointHistory,
   PointHistoryConstructorParams,
-} from '@sight/app/domain/user/model/PointHistory';
+} from '@khlug/app/domain/user/model/PointHistory';
 
 type PointHistoryCreateParams = Omit<
   PointHistoryConstructorParams,

--- a/src/app/domain/user/event/UserProfileUpdated.ts
+++ b/src/app/domain/user/event/UserProfileUpdated.ts
@@ -1,4 +1,4 @@
-import { User } from '@sight/app/domain/user/model/User';
+import { User } from '@khlug/app/domain/user/model/User';
 
 export class UserProfileUpdated {
   constructor(readonly user: User) {}

--- a/src/app/domain/user/model/Profile.ts
+++ b/src/app/domain/user/model/Profile.ts
@@ -1,4 +1,4 @@
-import { ValueObject } from '@sight/core/ddd/ValueObject';
+import { ValueObject } from '@khlug/core/ddd/ValueObject';
 
 export type ProfileConstructorParams = {
   name: string;

--- a/src/app/domain/user/model/User.spec.ts
+++ b/src/app/domain/user/model/User.spec.ts
@@ -1,10 +1,10 @@
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { UserState } from '@sight/app/domain/user/model/constant';
-import { User } from '@sight/app/domain/user/model/User';
+import { UserState } from '@khlug/app/domain/user/model/constant';
+import { User } from '@khlug/app/domain/user/model/User';
 
-import { DomainFixture } from '@sight/__test__/fixtures';
-import { Message } from '@sight/constant/message';
+import { DomainFixture } from '@khlug/__test__/fixtures';
+import { Message } from '@khlug/constant/message';
 
 describe('User', () => {
   let user: User;

--- a/src/app/domain/user/model/User.ts
+++ b/src/app/domain/user/model/User.ts
@@ -1,11 +1,11 @@
 import { UnprocessableEntityException } from '@nestjs/common';
 import { AggregateRoot } from '@nestjs/cqrs';
 
-import { UserProfileUpdated } from '@sight/app/domain/user/event/UserProfileUpdated';
-import { UserState } from '@sight/app/domain/user/model/constant';
-import { Profile } from '@sight/app/domain/user/model/Profile';
+import { UserProfileUpdated } from '@khlug/app/domain/user/event/UserProfileUpdated';
+import { UserState } from '@khlug/app/domain/user/model/constant';
+import { Profile } from '@khlug/app/domain/user/model/Profile';
 
-import { Message } from '@sight/constant/message';
+import { Message } from '@khlug/constant/message';
 
 export type UserConstructorParams = {
   id: string;

--- a/src/app/domain/user/service/PointGrantService.spec.ts
+++ b/src/app/domain/user/service/PointGrantService.spec.ts
@@ -1,15 +1,16 @@
+import { faker } from '@faker-js/faker';
 import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { PointGrantService } from './PointGrantService';
-import { IUserRepository, UserRepository } from '../IUserRepository';
-import { PointHistoryFactory } from '../PointHistoryFactory';
+import { DomainFixture } from '@khlug/__test__/fixtures';
+
 import {
   IPointHistoryRepository,
   PointHistoryRepository,
 } from '../IPointHistoryRepository';
-import { faker } from '@faker-js/faker';
-import { DomainFixture } from '@sight/__test__/fixtures';
+import { IUserRepository, UserRepository } from '../IUserRepository';
+import { PointHistoryFactory } from '../PointHistoryFactory';
+import { PointGrantService } from './PointGrantService';
 
 describe('PointGrantService', () => {
   let pointGrantService: PointGrantService;

--- a/src/app/domain/user/service/PointGrantService.ts
+++ b/src/app/domain/user/service/PointGrantService.ts
@@ -1,14 +1,14 @@
 import { Inject, Injectable } from '@nestjs/common';
 
-import { PointHistoryFactory } from '@sight/app/domain/user/PointHistoryFactory';
-import {
-  IUserRepository,
-  UserRepository,
-} from '@sight/app/domain/user/IUserRepository';
 import {
   IPointHistoryRepository,
   PointHistoryRepository,
-} from '@sight/app/domain/user/IPointHistoryRepository';
+} from '@khlug/app/domain/user/IPointHistoryRepository';
+import {
+  IUserRepository,
+  UserRepository,
+} from '@khlug/app/domain/user/IUserRepository';
+import { PointHistoryFactory } from '@khlug/app/domain/user/PointHistoryFactory';
 
 @Injectable()
 export class PointGrantService {

--- a/src/app/infra/logger/GroupLogger.spec.ts
+++ b/src/app/infra/logger/GroupLogger.spec.ts
@@ -2,18 +2,18 @@ import { Test } from '@nestjs/testing';
 import { advanceTo, clear } from 'jest-date-mock';
 import { ClsService } from 'nestjs-cls';
 
-import { IRequester } from '@sight/core/auth/IRequester';
-import { UserRole } from '@sight/core/auth/UserRole';
+import { IRequester } from '@khlug/core/auth/IRequester';
+import { UserRole } from '@khlug/core/auth/UserRole';
 
-import { GroupLoggerImpl } from '@sight/app/infra/logger/GroupLogger';
+import { GroupLoggerImpl } from '@khlug/app/infra/logger/GroupLogger';
 
-import { GroupLogFactory } from '@sight/app/domain/group/GroupLogFactory';
+import { GroupLogFactory } from '@khlug/app/domain/group/GroupLogFactory';
 import {
   GroupLogRepository,
   IGroupLogRepository,
-} from '@sight/app/domain/group/IGroupLogRepository';
+} from '@khlug/app/domain/group/IGroupLogRepository';
 
-import { generateEmptyProviders } from '@sight/__test__/util';
+import { generateEmptyProviders } from '@khlug/__test__/util';
 
 describe('GroupLogger', () => {
   let groupLogger: GroupLoggerImpl;

--- a/src/app/infra/logger/GroupLogger.ts
+++ b/src/app/infra/logger/GroupLogger.ts
@@ -1,14 +1,14 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ClsService } from 'nestjs-cls';
 
-import { IRequester } from '@sight/core/auth/IRequester';
+import { IRequester } from '@khlug/core/auth/IRequester';
 
-import { GroupLogFactory } from '@sight/app/domain/group/GroupLogFactory';
-import { IGroupLogger } from '@sight/app/domain/group/IGroupLogger';
+import { GroupLogFactory } from '@khlug/app/domain/group/GroupLogFactory';
+import { IGroupLogger } from '@khlug/app/domain/group/IGroupLogger';
 import {
   GroupLogRepository,
   IGroupLogRepository,
-} from '@sight/app/domain/group/IGroupLogRepository';
+} from '@khlug/app/domain/group/IGroupLogRepository';
 
 @Injectable()
 export class GroupLoggerImpl implements IGroupLogger {

--- a/src/core/auth/AuthGuard.ts
+++ b/src/core/auth/AuthGuard.ts
@@ -1,18 +1,20 @@
-import { Request } from 'express';
-import { ClsService } from 'nestjs-cls';
+import { EntityRepository } from '@mikro-orm/core';
+import { InjectRepository } from '@mikro-orm/nestjs';
 import {
   CanActivate,
   ExecutionContext,
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
+import { Request } from 'express';
+import { ClsService } from 'nestjs-cls';
 
-import { Message } from '@sight/constant/message';
-import { LaravelAuthnAdapter } from './LaravelAuthnAdapter';
+import { User } from '@khlug/app/domain/user/model/User';
+
+import { Message } from '@khlug/constant/message';
+
 import { IRequester } from './IRequester';
-import { InjectRepository } from '@mikro-orm/nestjs';
-import { User } from '@sight/app/domain/user/model/User';
-import { EntityRepository } from '@mikro-orm/core';
+import { LaravelAuthnAdapter } from './LaravelAuthnAdapter';
 import { UserRole } from './UserRole';
 
 @Injectable()

--- a/src/core/auth/AuthModule.ts
+++ b/src/core/auth/AuthModule.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 
-import { AuthGuard } from '@sight/core/auth/AuthGuard';
+import { AuthGuard } from '@khlug/core/auth/AuthGuard';
 
 @Module({
   providers: [

--- a/src/core/auth/IRequester.ts
+++ b/src/core/auth/IRequester.ts
@@ -1,4 +1,4 @@
-import { UserRole } from '@sight/core/auth/UserRole';
+import { UserRole } from '@khlug/core/auth/UserRole';
 
 export interface IRequester {
   userId: string;

--- a/src/core/auth/LaravelAuthnAdapter.ts
+++ b/src/core/auth/LaravelAuthnAdapter.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import fs from 'fs/promises';
 import crypto from 'crypto';
+import fs from 'fs/promises';
 import { unserialize } from 'php-serialize';
 
 import { LaravelSessionConfig } from '../config/LaravelSessionConfig';

--- a/src/core/config/index.ts
+++ b/src/core/config/index.ts
@@ -1,5 +1,5 @@
-import * as db from '@sight/core/config/DatabaseConfig';
-import * as session from '@sight/core/config/LaravelSessionConfig';
+import * as db from '@khlug/core/config/DatabaseConfig';
+import * as session from '@khlug/core/config/LaravelSessionConfig';
 
 export const configuration = (): {
   database: db.DatabaseConfig;

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -3,8 +3,8 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ClsModule } from 'nestjs-cls';
 
-import { DatabaseConfig } from '@sight/core/config/DatabaseConfig';
-import { TransactionModule } from '@sight/core/persistence/transaction/TransactionModule';
+import { DatabaseConfig } from '@khlug/core/config/DatabaseConfig';
+import { TransactionModule } from '@khlug/core/persistence/transaction/TransactionModule';
 
 @Module({
   imports: [

--- a/src/core/message/MessageBuilder.spec.ts
+++ b/src/core/message/MessageBuilder.spec.ts
@@ -1,6 +1,6 @@
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { MessageBuilder } from '@sight/core/message/MessageBuilder';
+import { MessageBuilder } from '@khlug/core/message/MessageBuilder';
 
 describe('MessageBuilder', () => {
   beforeEach(() => advanceTo(new Date()));

--- a/src/core/persistence/transaction/TransactionMethodExplorer.ts
+++ b/src/core/persistence/transaction/TransactionMethodExplorer.ts
@@ -4,9 +4,9 @@ import { ICommandHandler, IEventHandler } from '@nestjs/cqrs';
 
 import {
   COMMAND_HANDLER_METADATA,
-  TRANSACTIONAL_DECORATOR,
   EVENTS_HANDLER_METADATA,
-} from '@sight/core/persistence/transaction/constant';
+  TRANSACTIONAL_DECORATOR,
+} from '@khlug/core/persistence/transaction/constant';
 
 @Injectable()
 export class TransactionMethodExplorer {

--- a/src/core/persistence/transaction/TransactionModule.ts
+++ b/src/core/persistence/transaction/TransactionModule.ts
@@ -1,7 +1,7 @@
 import { Module, OnModuleInit } from '@nestjs/common';
 import { DiscoveryModule } from '@nestjs/core';
 
-import { TransactionalApplier } from '@sight/core/persistence/transaction/TransactionalApplier';
+import { TransactionalApplier } from '@khlug/core/persistence/transaction/TransactionalApplier';
 
 @Module({
   imports: [DiscoveryModule],

--- a/src/core/persistence/transaction/Transactional.spec.ts
+++ b/src/core/persistence/transaction/Transactional.spec.ts
@@ -13,9 +13,9 @@
 //   PrimaryKey,
 // } from '@mikro-orm/core';
 
-// import { TRANSACTIONAL_ENTITY_MANAGER } from '@sight/core/persistence/transaction/constant';
-// import { Transactional } from '@sight/core/persistence/transaction/Transactional';
-// import { TransactionalDecorator } from '@sight/core/persistence/transaction/TransactionalDecorator';
+// import { TRANSACTIONAL_ENTITY_MANAGER } from '@khlug/core/persistence/transaction/constant';
+// import { Transactional } from '@khlug/core/persistence/transaction/Transactional';
+// import { TransactionalDecorator } from '@khlug/core/persistence/transaction/TransactionalDecorator';
 
 // @Entity({ tableName: 'Mock' })
 // class MockEntity {

--- a/src/core/persistence/transaction/Transactional.ts
+++ b/src/core/persistence/transaction/Transactional.ts
@@ -1,8 +1,8 @@
 import { ICommandHandler, IEventHandler } from '@nestjs/cqrs';
 
-import { TRANSACTIONAL_DECORATOR } from '@sight/core/persistence/transaction/constant';
+import { TRANSACTIONAL_DECORATOR } from '@khlug/core/persistence/transaction/constant';
 
-import { IsAsyncFunction } from '@sight/util/types';
+import { IsAsyncFunction } from '@khlug/util/types';
 
 export type KeyOf<T extends ICommandHandler | IEventHandler> =
   T extends ICommandHandler

--- a/src/core/persistence/transaction/TransactionalApplier.ts
+++ b/src/core/persistence/transaction/TransactionalApplier.ts
@@ -3,8 +3,8 @@ import { Injectable } from '@nestjs/common';
 import { ICommandHandler, IEventHandler } from '@nestjs/cqrs';
 import { ClsService } from 'nestjs-cls';
 
-import { TRANSACTIONAL_ENTITY_MANAGER } from '@sight/core/persistence/transaction/constant';
-import { TransactionMethodExplorer } from '@sight/core/persistence/transaction/TransactionMethodExplorer';
+import { TRANSACTIONAL_ENTITY_MANAGER } from '@khlug/core/persistence/transaction/constant';
+import { TransactionMethodExplorer } from '@khlug/core/persistence/transaction/TransactionMethodExplorer';
 
 type AsyncFn = (...args: any[]) => Promise<any>;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 
-import { AppModule } from '@sight/app.module';
+import { AppModule } from '@khlug/app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/src/util/isDifferentStringArray.spec.ts
+++ b/src/util/isDifferentStringArray.spec.ts
@@ -1,4 +1,4 @@
-import { isDifferentStringArray } from '@sight/util/isDifferentStringArray';
+import { isDifferentStringArray } from '@khlug/util/isDifferentStringArray';
 
 describe('isDifferentStringArray', () => {
   test('같은 항목, 같은 순서를 갖는 두 배열에 대해 false를 반환해야 한다', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,8 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "paths": {
-      "@sight": ["src"],
-      "@sight/*": ["src/*"]
+      "@khlug": ["src"],
+      "@khlug/*": ["src/*"]
     },
     "incremental": true,
     "skipLibCheck": true,


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

import문 정렬 린트를 추가하고 적용합니다.
또, import prefix를 `@sight`에서 `@khlug`로 적용합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

코드 컨벤션을 강제하기 위함입니다.