### PR TITLE
fix: 프로덕션 환경에서는 특정 Origin만 참조하도록 수정

### DIFF
--- a/src/core/config/AppConfig.ts
+++ b/src/core/config/AppConfig.ts
@@ -1,0 +1,14 @@
+export type AppConfig = {
+  env: 'development' | 'production';
+};
+
+const validateEnv = (env: string = 'development'): AppConfig['env'] => {
+  if (env !== 'development' && env !== 'production') {
+    throw new Error(`Invalid NODE_ENV: ${env}`);
+  }
+  return env as AppConfig['env'];
+};
+
+export const config = (): AppConfig => ({
+  env: validateEnv(process.env.NODE_ENV),
+});

--- a/src/core/config/index.ts
+++ b/src/core/config/index.ts
@@ -1,10 +1,13 @@
+import * as app from '@khlug/core/config/AppConfig';
 import * as db from '@khlug/core/config/DatabaseConfig';
 import * as session from '@khlug/core/config/LaravelSessionConfig';
 
 export const configuration = (): {
+  app: app.AppConfig;
   database: db.DatabaseConfig;
   session: session.LaravelSessionConfig;
 } => ({
+  app: app.config(),
   database: db.config(),
   session: session.config(),
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,23 @@
+import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
+import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import cookieParser from 'cookie-parser';
+
+import { AppConfig } from '@khlug/core/config/AppConfig';
 
 import { RootModule } from '@khlug/RootModule';
 
 async function bootstrap() {
   const app = await NestFactory.create(RootModule);
 
+  const appConfig = app.get(ConfigService).getOrThrow<AppConfig>('app');
+  const corsOptions: CorsOptions | undefined =
+    appConfig.env === 'production'
+      ? { origin: ['https://khlug.org', 'https://app.khlug.org'] }
+      : undefined;
+
+  app.enableCors(corsOptions);
   app.use(cookieParser());
-  app.enableCors();
 
   await app.listen(3000);
 }


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

프로덕션 환경에서는 특정 origin만 CORS가 허용되도록 수정합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

axios에서 `withCredentials`를 통해 쿠키와 함께 요청을 보내면, 서버의 응답 헤더에서 `Access-Control-Allow-Origin`의 값에 와일드카드를 사용하는 경우 보안 문제로 CORS 에러를 일으킵니다. 따라서, 프로덕션 환경에서는 특정 도메인만 허용하도록 합니다.

```
Access to XMLHttpRequest at 'https://api.khlug.org/manager/door-lock-password' from origin 'https://app.khlug.org' has been blocked by CORS policy: The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.
```