### PR TITLE
fix: Access-Control-Allow-Credentials 응답 헤더에 true 포함

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,10 @@ async function bootstrap() {
   const appConfig = app.get(ConfigService).getOrThrow<AppConfig>('app');
   const corsOptions: CorsOptions | undefined =
     appConfig.env === 'production'
-      ? { origin: ['https://khlug.org', 'https://app.khlug.org'] }
+      ? {
+          origin: ['https://khlug.org', 'https://app.khlug.org'],
+          credentials: true,
+        }
       : undefined;
 
   app.enableCors(corsOptions);


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

`Access-Control-Allow-Credentials` 응답 헤더로 `true` 값을 보내도록 수정합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

`withCredentials: true`인 경우 해당 헤더가 `true`일 때만 정상 동작한다는 CORS 에러가 발생하여, 이를 해결하기 위함입니다.