### PR TITLE
fix: 유저 목록 응답에서 비밀번호 제거

### DIFF
--- a/src/app/application/user/query/view/UserView.ts
+++ b/src/app/application/user/query/view/UserView.ts
@@ -15,7 +15,6 @@ export interface ProfileView {
 export interface UserView {
   id: number;
   name: string;
-  password: string | null;
   profile: ProfileView;
   admission: string;
   state: UserState;

--- a/src/app/interface/user/manager/dto/ListUserResponseDto.ts
+++ b/src/app/interface/user/manager/dto/ListUserResponseDto.ts
@@ -15,7 +15,6 @@ export class ListUserResponseDto {
       users: view.users.map((user) => ({
         id: user.id,
         name: user.name,
-        password: user.password,
         profile: {
           name: user.profile.name,
           college: user.profile.college,

--- a/src/app/interface/user/manager/dto/common/UserResponse.ts
+++ b/src/app/interface/user/manager/dto/common/UserResponse.ts
@@ -15,7 +15,6 @@ export class UserProfileResponse {
 export class UserResponse {
   id!: number;
   name!: string;
-  password!: string | null;
   profile!: UserProfileResponse;
   admission!: string;
   state!: UserState;


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

유저 목록 응답에서 비밀번호를 제거합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

비밀번호는 응답에 포함되어도 불필요하고, 해시 처리가 되어 있긴 하나 보안 문제가 발생할 수 있으므로 응답에서 제거합니다.