### PR TITLE
fix: state 및 active 프로퍼티의 이름을 적절하게 수정

### DIFF
--- a/src/__test__/fixtures/domain/user.ts
+++ b/src/__test__/fixtures/domain/user.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 
-import { UserState } from '@khlug/app/domain/user/model/constant';
+import { StudentStatus } from '@khlug/app/domain/user/model/constant';
 import {
   PointHistory,
   PointHistoryConstructorParams,
@@ -25,7 +25,7 @@ export function generateUser(params?: Partial<UserConstructorParams>): User {
       prefer: faker.lorem.word(),
     }),
     admission: faker.lorem.word(),
-    state: faker.helpers.enumValue(UserState),
+    studentStatus: faker.helpers.enumValue(StudentStatus),
     point: faker.number.int(),
     active: faker.datatype.boolean(),
     manager: faker.datatype.boolean(),

--- a/src/__test__/fixtures/domain/user.ts
+++ b/src/__test__/fixtures/domain/user.ts
@@ -1,6 +1,9 @@
 import { faker } from '@faker-js/faker';
 
-import { StudentStatus } from '@khlug/app/domain/user/model/constant';
+import {
+  StudentStatus,
+  UserStatus,
+} from '@khlug/app/domain/user/model/constant';
 import {
   PointHistory,
   PointHistoryConstructorParams,
@@ -27,7 +30,7 @@ export function generateUser(params?: Partial<UserConstructorParams>): User {
     admission: faker.lorem.word(),
     studentStatus: faker.helpers.enumValue(StudentStatus),
     point: faker.number.int(),
-    active: faker.datatype.boolean(),
+    status: faker.helpers.enumValue(UserStatus),
     manager: faker.datatype.boolean(),
     slack: faker.lorem.word(),
     rememberToken: faker.lorem.word(),

--- a/src/__test__/fixtures/view/user.ts
+++ b/src/__test__/fixtures/view/user.ts
@@ -5,7 +5,10 @@ import { InterestView } from '@khlug/app/application/interest/query/view/Interes
 import { UserListView } from '@khlug/app/application/user/query/view/UserListView';
 import { UserView } from '@khlug/app/application/user/query/view/UserView';
 
-import { StudentStatus } from '@khlug/app/domain/user/model/constant';
+import {
+  StudentStatus,
+  UserStatus,
+} from '@khlug/app/domain/user/model/constant';
 
 export function generateUserView(params?: Partial<UserView>): UserView {
   return {
@@ -25,7 +28,7 @@ export function generateUserView(params?: Partial<UserView>): UserView {
     admission: faker.lorem.word(),
     studentStatus: faker.helpers.enumValue(StudentStatus),
     point: faker.number.int(),
-    active: faker.datatype.boolean(),
+    status: faker.helpers.enumValue(UserStatus),
     manager: faker.datatype.boolean(),
     slack: faker.lorem.word(),
     rememberToken: faker.lorem.word(),

--- a/src/__test__/fixtures/view/user.ts
+++ b/src/__test__/fixtures/view/user.ts
@@ -5,7 +5,7 @@ import { InterestView } from '@khlug/app/application/interest/query/view/Interes
 import { UserListView } from '@khlug/app/application/user/query/view/UserListView';
 import { UserView } from '@khlug/app/application/user/query/view/UserView';
 
-import { UserState } from '@khlug/app/domain/user/model/constant';
+import { StudentStatus } from '@khlug/app/domain/user/model/constant';
 
 export function generateUserView(params?: Partial<UserView>): UserView {
   return {
@@ -23,7 +23,7 @@ export function generateUserView(params?: Partial<UserView>): UserView {
       prefer: faker.lorem.word(),
     },
     admission: faker.lorem.word(),
-    state: faker.helpers.enumValue(UserState),
+    studentStatus: faker.helpers.enumValue(StudentStatus),
     point: faker.number.int(),
     active: faker.datatype.boolean(),
     manager: faker.datatype.boolean(),

--- a/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandHandler.spec.ts
+++ b/src/app/application/user/command/updateUnitedUser/UpdateUnitedUserCommandHandler.spec.ts
@@ -8,7 +8,7 @@ import {
   IUserRepository,
   UserRepository,
 } from '@khlug/app/domain/user/IUserRepository';
-import { UserState } from '@khlug/app/domain/user/model/constant';
+import { StudentStatus } from '@khlug/app/domain/user/model/constant';
 import { User } from '@khlug/app/domain/user/model/User';
 
 import { generateUser } from '@khlug/__test__/fixtures/domain';
@@ -48,7 +48,7 @@ describe('UpdateUnitedUserCommandHandler', () => {
     const newEmail = 'new-email@email.com';
 
     beforeEach(() => {
-      user = generateUser({ id: userId, state: UserState.UNITED });
+      user = generateUser({ id: userId, studentStatus: StudentStatus.UNITED });
       command = new UpdateUnitedUserCommand(userId, newEmail);
 
       userRepository.findById = jest.fn().mockResolvedValue(user);

--- a/src/app/application/user/command/updateUser/UpdateUserCommandHandler.spec.ts
+++ b/src/app/application/user/command/updateUser/UpdateUserCommandHandler.spec.ts
@@ -23,7 +23,7 @@ import {
   IUserRepository,
   UserRepository,
 } from '@khlug/app/domain/user/IUserRepository';
-import { UserState } from '@khlug/app/domain/user/model/constant';
+import { StudentStatus } from '@khlug/app/domain/user/model/constant';
 import { User } from '@khlug/app/domain/user/model/User';
 
 import {
@@ -86,7 +86,7 @@ describe('UpdateUserCommandHandler', () => {
     const prefer = 'some-prefers';
 
     beforeEach(() => {
-      user = generateUser({ state: UserState.UNDERGRADUATE });
+      user = generateUser({ studentStatus: StudentStatus.UNDERGRADUATE });
       interests = interestIds.map((interestId) =>
         generateInterest({ id: interestId }),
       );

--- a/src/app/application/user/query/listUser/ListUserQuery.ts
+++ b/src/app/application/user/query/listUser/ListUserQuery.ts
@@ -1,6 +1,6 @@
 import { IQuery } from '@nestjs/cqrs';
 
-import { UserState } from '@khlug/app/domain/user/model/constant';
+import { StudentStatus } from '@khlug/app/domain/user/model/constant';
 
 import { Typeof } from '@khlug/util/types';
 
@@ -11,7 +11,7 @@ export class ListUserQuery implements IQuery {
   readonly number: string | null;
   readonly college: string | null;
   readonly grade: number | null;
-  readonly state: UserState | null;
+  readonly studentStatus: StudentStatus | null;
   readonly limit: number;
   readonly offset: number;
 
@@ -22,7 +22,7 @@ export class ListUserQuery implements IQuery {
     this.number = params.number;
     this.college = params.college;
     this.grade = params.grade;
-    this.state = params.state;
+    this.studentStatus = params.studentStatus;
     this.limit = params.limit;
     this.offset = params.offset;
   }

--- a/src/app/application/user/query/listUser/ListUserQueryHandler.ts
+++ b/src/app/application/user/query/listUser/ListUserQueryHandler.ts
@@ -20,8 +20,17 @@ export class ListUserQueryHandler
   ) {}
 
   async execute(query: ListUserQuery): Promise<ListUserQueryResult> {
-    const { email, phone, name, number, college, grade, state, limit, offset } =
-      query;
+    const {
+      email,
+      phone,
+      name,
+      number,
+      college,
+      grade,
+      studentStatus,
+      limit,
+      offset,
+    } = query;
 
     const qb = this.userRepository.createQueryBuilder('user');
 
@@ -49,8 +58,8 @@ export class ListUserQueryHandler
       qb.andWhere('grade = ?', [grade]);
     }
 
-    if (state) {
-      qb.andWhere('state = ?', [state]);
+    if (studentStatus) {
+      qb.andWhere('state = ?', [studentStatus]);
     }
 
     const [users, count] = await qb
@@ -88,7 +97,7 @@ export class ListUserQueryHandler
             prefer: user.profile.prefer,
           },
           admission: user.admission,
-          state: user.state,
+          studentStatus: user.studentStatus,
           point: user.point,
           active: user.active,
           manager: user.manager,

--- a/src/app/application/user/query/listUser/ListUserQueryHandler.ts
+++ b/src/app/application/user/query/listUser/ListUserQueryHandler.ts
@@ -99,7 +99,7 @@ export class ListUserQueryHandler
           admission: user.admission,
           studentStatus: user.studentStatus,
           point: user.point,
-          active: user.active,
+          status: user.status,
           manager: user.manager,
           slack: user.slack,
           rememberToken: user.rememberToken,

--- a/src/app/application/user/query/view/UserView.ts
+++ b/src/app/application/user/query/view/UserView.ts
@@ -1,4 +1,7 @@
-import { StudentStatus } from '@khlug/app/domain/user/model/constant';
+import {
+  StudentStatus,
+  UserStatus,
+} from '@khlug/app/domain/user/model/constant';
 
 export interface ProfileView {
   name: string;
@@ -19,7 +22,7 @@ export interface UserView {
   admission: string;
   studentStatus: StudentStatus;
   point: number;
-  active: boolean;
+  status: UserStatus;
   manager: boolean;
   slack: string | null;
   rememberToken: string | null;

--- a/src/app/application/user/query/view/UserView.ts
+++ b/src/app/application/user/query/view/UserView.ts
@@ -1,4 +1,4 @@
-import { UserState } from '@khlug/app/domain/user/model/constant';
+import { StudentStatus } from '@khlug/app/domain/user/model/constant';
 
 export interface ProfileView {
   name: string;
@@ -17,7 +17,7 @@ export interface UserView {
   name: string;
   profile: ProfileView;
   admission: string;
-  state: UserState;
+  studentStatus: StudentStatus;
   point: number;
   active: boolean;
   manager: boolean;

--- a/src/app/domain/user/model/User.spec.ts
+++ b/src/app/domain/user/model/User.spec.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { advanceTo, clear } from 'jest-date-mock';
 
-import { UserState } from '@khlug/app/domain/user/model/constant';
+import { StudentStatus } from '@khlug/app/domain/user/model/constant';
 
 import { DomainFixture } from '@khlug/__test__/fixtures';
 import { Message } from '@khlug/constant/message';
@@ -23,7 +23,9 @@ describe('User', () => {
     const name = '김러리';
 
     test('교류 회원이 이메일 외에 다른 정보를 변경할 때, 예외를 발생시켜야 한다', () => {
-      const user = DomainFixture.generateUser({ state: UserState.UNITED });
+      const user = DomainFixture.generateUser({
+        studentStatus: StudentStatus.UNITED,
+      });
 
       expect(() => user.setProfile({ phone: '010-0000-0000' })).toThrowError(
         Message.UNITED_USER_CAN_ONLY_CHANGE_EMAIL,
@@ -32,7 +34,7 @@ describe('User', () => {
 
     test('졸업 상태가 아닌 유저가 전화번호를 변경할 때, 예외를 발생시켜야 한다', () => {
       const user = DomainFixture.generateUser({
-        state: UserState.UNDERGRADUATE,
+        studentStatus: StudentStatus.UNDERGRADUATE,
       });
 
       expect(() => user.setProfile({ phone: '010-0000-0000' })).toThrowError(
@@ -42,7 +44,7 @@ describe('User', () => {
 
     test('주어진 프로필 정보로 유저의 프로필을 수정해야 한다', () => {
       const user = DomainFixture.generateUser({
-        state: UserState.UNDERGRADUATE,
+        studentStatus: StudentStatus.UNDERGRADUATE,
       });
 
       user.setProfile({ email, grade, name });
@@ -54,7 +56,7 @@ describe('User', () => {
 
     test('수정 후, updatedAt의 값이 갱신돼야 한다', () => {
       const user = DomainFixture.generateUser({
-        state: UserState.UNDERGRADUATE,
+        studentStatus: StudentStatus.UNDERGRADUATE,
       });
 
       user.setProfile({ email, grade, name });
@@ -65,7 +67,7 @@ describe('User', () => {
   describe('login', () => {
     test('로그인 할 때, lastLoginAt의 값이 지금 시각으로 변경되어야 한다', () => {
       const user = DomainFixture.generateUser({
-        state: UserState.UNDERGRADUATE,
+        studentStatus: StudentStatus.UNDERGRADUATE,
       });
 
       user.login();
@@ -75,7 +77,7 @@ describe('User', () => {
 
     test('로그인 할 때, updatedAt의 값이 갱신돼야 한다', () => {
       const user = DomainFixture.generateUser({
-        state: UserState.UNDERGRADUATE,
+        studentStatus: StudentStatus.UNDERGRADUATE,
       });
 
       user.login();
@@ -110,12 +112,16 @@ describe('User', () => {
   describe('needAuth', () => {
     describe('대상 유저가 아닌 경우', () => {
       test('교류 유저라면 `false`를 반환해야 한다', () => {
-        const user = DomainFixture.generateUser({ state: UserState.UNITED });
+        const user = DomainFixture.generateUser({
+          studentStatus: StudentStatus.UNITED,
+        });
         expect(user.needAuth()).toEqual(false);
       });
 
       test('졸업한 유저라면 `false`를 반환해야 한다', () => {
-        const user = DomainFixture.generateUser({ state: UserState.GRADUATE });
+        const user = DomainFixture.generateUser({
+          studentStatus: StudentStatus.GRADUATE,
+        });
         expect(user.needAuth()).toEqual(false);
       });
 
@@ -128,7 +134,7 @@ describe('User', () => {
     describe('대상 유저인 경우', () => {
       const createTargetUser = (khuisAuthAt: Date) =>
         DomainFixture.generateUser({
-          state: UserState.UNDERGRADUATE,
+          studentStatus: StudentStatus.UNDERGRADUATE,
           returnAt: null,
           khuisAuthAt,
         });

--- a/src/app/domain/user/model/User.ts
+++ b/src/app/domain/user/model/User.ts
@@ -19,7 +19,7 @@ import {
 import dayjs from 'dayjs';
 
 import { UserProfileUpdated } from '@khlug/app/domain/user/event/UserProfileUpdated';
-import { UserState } from '@khlug/app/domain/user/model/constant';
+import { StudentStatus } from '@khlug/app/domain/user/model/constant';
 import { Profile } from '@khlug/app/domain/user/model/Profile';
 
 import { Message } from '@khlug/constant/message';
@@ -30,7 +30,7 @@ export type UserConstructorParams = {
   password: string | null;
   profile: Profile;
   admission: string;
-  state: UserState;
+  studentStatus: StudentStatus;
   point: number;
   active: boolean;
   manager: boolean;
@@ -71,7 +71,7 @@ export class User extends AggregateRoot {
 
   @Property({ type: 'int', name: 'state' })
   @IsInt()
-  private _state: UserState;
+  private _studentStatus: StudentStatus;
 
   @Property({ type: 'int', name: 'expoint' })
   @IsInt()
@@ -153,7 +153,7 @@ export class User extends AggregateRoot {
     this._password = params.password;
     this._profile = params.profile;
     this._admission = params.admission;
-    this._state = params.state;
+    this._studentStatus = params.studentStatus;
     this._point = params.point;
     this._active = params.active;
     this._manager = params.manager;
@@ -171,14 +171,14 @@ export class User extends AggregateRoot {
   setProfile(profile: Partial<Profile>): void {
     if (
       !(Object.keys(profile).length === 1 && profile.email) &&
-      this.state === UserState.UNITED
+      this.studentStatus === StudentStatus.UNITED
     ) {
       throw new UnprocessableEntityException(
         Message.UNITED_USER_CAN_ONLY_CHANGE_EMAIL,
       );
     }
 
-    if (profile.phone && this.state !== UserState.GRADUATE) {
+    if (profile.phone && this.studentStatus !== StudentStatus.GRADUATE) {
       throw new UnprocessableEntityException(
         Message.GRADUATED_USER_ONLY_CAN_CHANGE_EMAIL,
       );
@@ -205,9 +205,9 @@ export class User extends AggregateRoot {
   }
 
   needAuth(): boolean {
-    const checkTargetStates: UserState[] = [
-      UserState.ABSENCE,
-      UserState.UNDERGRADUATE,
+    const checkTargetStudentStatus: StudentStatus[] = [
+      StudentStatus.ABSENCE,
+      StudentStatus.UNDERGRADUATE,
     ];
 
     const today = dayjs().tz('Asia/Seoul');
@@ -229,7 +229,8 @@ export class User extends AggregateRoot {
       khuisAuthAtMMDD >= '0220' && khuisAuthAtMMDD < '0820' ? 1 : 2;
 
     const isTarget =
-      checkTargetStates.includes(this._state) && !this.isStopped();
+      checkTargetStudentStatus.includes(this._studentStatus) &&
+      !this.isStopped();
     const authedInThisSemester =
       `${currentYear}-${currentSemester}` <=
       `${lastAuthYear}-${lastAuthSemester}`;
@@ -257,8 +258,8 @@ export class User extends AggregateRoot {
     return this._admission;
   }
 
-  get state(): UserState {
-    return this._state;
+  get studentStatus(): StudentStatus {
+    return this._studentStatus;
   }
 
   get point(): number {

--- a/src/app/domain/user/model/User.ts
+++ b/src/app/domain/user/model/User.ts
@@ -19,7 +19,10 @@ import {
 import dayjs from 'dayjs';
 
 import { UserProfileUpdated } from '@khlug/app/domain/user/event/UserProfileUpdated';
-import { StudentStatus } from '@khlug/app/domain/user/model/constant';
+import {
+  StudentStatus,
+  UserStatus,
+} from '@khlug/app/domain/user/model/constant';
 import { Profile } from '@khlug/app/domain/user/model/Profile';
 
 import { Message } from '@khlug/constant/message';
@@ -32,7 +35,7 @@ export type UserConstructorParams = {
   admission: string;
   studentStatus: StudentStatus;
   point: number;
-  active: boolean;
+  status: UserStatus;
   manager: boolean;
   slack: string | null;
   rememberToken: string | null;
@@ -79,7 +82,7 @@ export class User extends AggregateRoot {
 
   @Property({ type: 'tinyint', length: 1, name: 'active' })
   @IsBoolean()
-  private _active: boolean;
+  private _status: UserStatus;
 
   @Property({ type: 'tinyint', length: 1, name: 'manager' })
   @IsBoolean()
@@ -155,7 +158,7 @@ export class User extends AggregateRoot {
     this._admission = params.admission;
     this._studentStatus = params.studentStatus;
     this._point = params.point;
-    this._active = params.active;
+    this._status = params.status;
     this._manager = params.manager;
     this._slack = params.slack;
     this._rememberToken = params.rememberToken;
@@ -266,8 +269,8 @@ export class User extends AggregateRoot {
     return this._point;
   }
 
-  get active(): boolean {
-    return this._active;
+  get status(): UserStatus {
+    return this._status;
   }
 
   get manager(): boolean {

--- a/src/app/domain/user/model/constant.ts
+++ b/src/app/domain/user/model/constant.ts
@@ -5,3 +5,10 @@ export const StudentStatus = {
   GRADUATE: 2, // 졸업
 } as const;
 export type StudentStatus = (typeof StudentStatus)[keyof typeof StudentStatus];
+
+export const UserStatus = {
+  INACTIVE: -1, // 정지
+  UNAUTHORIZED: 0, // 미승인 혹은 탈퇴
+  ACTIVE: 1, // 활성
+} as const;
+export type UserStatus = (typeof UserStatus)[keyof typeof UserStatus];

--- a/src/app/domain/user/model/constant.ts
+++ b/src/app/domain/user/model/constant.ts
@@ -1,7 +1,7 @@
-export const UserState = {
+export const StudentStatus = {
   UNITED: -1, // 교류
   ABSENCE: 0, // 휴학
   UNDERGRADUATE: 1, // 재학
   GRADUATE: 2, // 졸업
 } as const;
-export type UserState = (typeof UserState)[keyof typeof UserState];
+export type StudentStatus = (typeof StudentStatus)[keyof typeof StudentStatus];

--- a/src/app/interface/user/manager/UserManageController.ts
+++ b/src/app/interface/user/manager/UserManageController.ts
@@ -28,7 +28,7 @@ export class UserManageController {
       number: dto.number,
       college: dto.college,
       grade: dto.grade,
-      state: dto.state,
+      studentStatus: dto.studentStatus,
       limit: dto.limit,
       offset: dto.offset,
     });

--- a/src/app/interface/user/manager/dto/ListUserRequestDto.ts
+++ b/src/app/interface/user/manager/dto/ListUserRequestDto.ts
@@ -10,7 +10,7 @@ import {
   Min,
 } from 'class-validator';
 
-import { UserState } from '@khlug/app/domain/user/model/constant';
+import { StudentStatus } from '@khlug/app/domain/user/model/constant';
 
 export class ListUserRequestDto {
   @IsOptional()
@@ -46,8 +46,8 @@ export class ListUserRequestDto {
 
   @Type(() => Number)
   @IsOptional()
-  @IsEnum(UserState)
-  state: UserState | null = null;
+  @IsEnum(StudentStatus)
+  studentStatus: StudentStatus | null = null;
 
   @Type(() => Number)
   @IsInt()

--- a/src/app/interface/user/manager/dto/ListUserResponseDto.ts
+++ b/src/app/interface/user/manager/dto/ListUserResponseDto.ts
@@ -27,7 +27,7 @@ export class ListUserResponseDto {
           prefer: user.profile.prefer,
         },
         admission: user.admission,
-        state: user.state,
+        studentStatus: user.studentStatus,
         point: user.point,
         active: user.active,
         manager: user.manager,

--- a/src/app/interface/user/manager/dto/ListUserResponseDto.ts
+++ b/src/app/interface/user/manager/dto/ListUserResponseDto.ts
@@ -29,7 +29,7 @@ export class ListUserResponseDto {
         admission: user.admission,
         studentStatus: user.studentStatus,
         point: user.point,
-        active: user.active,
+        status: user.status,
         manager: user.manager,
         slack: user.slack,
         rememberToken: user.rememberToken,

--- a/src/app/interface/user/manager/dto/common/UserResponse.ts
+++ b/src/app/interface/user/manager/dto/common/UserResponse.ts
@@ -1,4 +1,7 @@
-import { StudentStatus } from '@khlug/app/domain/user/model/constant';
+import {
+  StudentStatus,
+  UserStatus,
+} from '@khlug/app/domain/user/model/constant';
 
 export class UserProfileResponse {
   name!: string;
@@ -19,7 +22,7 @@ export class UserResponse {
   admission!: string;
   studentStatus!: StudentStatus;
   point!: number;
-  active!: boolean;
+  status!: UserStatus;
   manager!: boolean;
   slack!: string | null;
   rememberToken!: string | null;

--- a/src/app/interface/user/manager/dto/common/UserResponse.ts
+++ b/src/app/interface/user/manager/dto/common/UserResponse.ts
@@ -1,4 +1,4 @@
-import { UserState } from '@khlug/app/domain/user/model/constant';
+import { StudentStatus } from '@khlug/app/domain/user/model/constant';
 
 export class UserProfileResponse {
   name!: string;
@@ -17,7 +17,7 @@ export class UserResponse {
   name!: string;
   profile!: UserProfileResponse;
   admission!: string;
-  state!: UserState;
+  studentStatus!: StudentStatus;
   point!: number;
   active!: boolean;
   manager!: boolean;


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

`state`를 `studentStatus`로, `active`를 `status`로 수정하였습니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

`state`는 학적 상태를 나타내고 있습니다. 따라서 `studentStatus`로 수정하였습니다.

또한, `active`의 실제 데이터를 살펴보니 `-1, 0, 1` 3개의 값을 가지며 true / false flag가 아니었습니다. 따라서 이를 반영하여 `UserStatus`를 정의하고 적용하였습니다.