### PR TITLE
fix: 잘못된 회비 납부 대상 판단 로직 수정

### DIFF
--- a/jest/setup.ts
+++ b/jest/setup.ts
@@ -1,6 +1,8 @@
 import dayjs from 'dayjs';
+import isBetween from 'dayjs/plugin/isBetween';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 
 dayjs.extend(timezone);
 dayjs.extend(utc);
+dayjs.extend(isBetween);

--- a/src/__test__/fixtures/domain/user.ts
+++ b/src/__test__/fixtures/domain/user.ts
@@ -47,6 +47,13 @@ function stopped(params: Partial<UserConstructorParams> = {}) {
   });
 }
 
+function graduated(params: Partial<UserConstructorParams> = {}) {
+  return generateUser({
+    studentStatus: StudentStatus.GRADUATE,
+    ...params,
+  });
+}
+
 export function generateProfile(
   params: Partial<ProfileConstructorParams> = {},
 ): Profile {
@@ -80,4 +87,5 @@ export function generatePointHistory(
 export const UserFixture = {
   raw: generateUser,
   stopped,
+  graduated,
 };

--- a/src/__test__/fixtures/domain/user.ts
+++ b/src/__test__/fixtures/domain/user.ts
@@ -40,6 +40,13 @@ export function generateUser(
   });
 }
 
+function stopped(params: Partial<UserConstructorParams> = {}) {
+  return generateUser({
+    returnAt: new Date(),
+    ...params,
+  });
+}
+
 export function generateProfile(
   params: Partial<ProfileConstructorParams> = {},
 ): Profile {
@@ -69,3 +76,8 @@ export function generatePointHistory(
     ...params,
   });
 }
+
+export const UserFixture = {
+  raw: generateUser,
+  stopped,
+};

--- a/src/app/domain/user/model/User.spec.ts
+++ b/src/app/domain/user/model/User.spec.ts
@@ -327,6 +327,7 @@ describe('User', () => {
         manager: params.manager ?? false,
         profile: generateProfile({ grade: params.grade ?? 1 }),
         createdAt: params.createdAt ?? new Date('2025-05-01'),
+        returnAt: null,
       });
 
     test('정지 상태인 경우 `false`를 반환해야 한다', () => {
@@ -335,7 +336,7 @@ describe('User', () => {
     });
 
     test('재학 중이 아닌 경우 `false`를 반환해야 한다', () => {
-      const user = createUser({ studentStatus: StudentStatus.GRADUATE });
+      const user = UserFixture.graduated();
       expect(user.needPayFee()).toEqual(false);
     });
 
@@ -344,21 +345,43 @@ describe('User', () => {
       expect(user.needPayFee()).toEqual(false);
     });
 
-    test('4학년인 경우 `false`를 반환해야 한다', () => {
-      const user = createUser({ grade: 4 });
-      expect(user.needPayFee()).toEqual(false);
-    });
-
-    test('등록한지 309일이 안 된 경우 `false`를 반환해야 한다', () => {
+    test('등록한지 1년이 지났고, 4학년인 경우 `false`를 반환해야 한다', () => {
       const user = createUser({
-        createdAt: dayjs().subtract(308, 'days').toDate(),
+        grade: 4,
+        createdAt: createKstDate('2024-05-01'),
       });
+      advanceTo(createKstDate('2025-05-01'));
+
       expect(user.needPayFee()).toEqual(false);
     });
 
-    test('회비 납부 대상인 경우 `true`를 반환해야 한다', () => {
-      const user = createUser({ createdAt: createKstDate('2024-05-01') });
-      advanceTo(createKstDate('2025-05-01'));
+    test('등록한지 1년이 지나지 않았고, 4학년인 경우 `true`를 반환해야 한다', () => {
+      const user = createUser({
+        grade: 4,
+        createdAt: createKstDate('2025-05-01'),
+      });
+      advanceTo(createKstDate('2026-04-30'));
+
+      expect(user.needPayFee()).toEqual(true);
+    });
+
+    test('등록한지 1년이 지나지 않았고, 4학년 미만인 경우 `true`를 반환해야 한다', () => {
+      const user = createUser({
+        grade: 3,
+        createdAt: createKstDate('2025-05-01'),
+      });
+      advanceTo(createKstDate('2026-04-30'));
+
+      expect(user.needPayFee()).toEqual(true);
+    });
+
+    test('등록한지 1년이 지났고, 4학년 미만인 경우 `true`를 반환해야 한다', () => {
+      const user = createUser({
+        grade: 3,
+        createdAt: createKstDate('2025-05-01'),
+      });
+      advanceTo(createKstDate('2026-05-01'));
+
       expect(user.needPayFee()).toEqual(true);
     });
   });

--- a/src/app/domain/user/model/User.spec.ts
+++ b/src/app/domain/user/model/User.spec.ts
@@ -4,7 +4,7 @@ import { advanceTo, clear } from 'jest-date-mock';
 import { StudentStatus } from '@khlug/app/domain/user/model/constant';
 
 import { DomainFixture } from '@khlug/__test__/fixtures';
-import { generateProfile } from '@khlug/__test__/fixtures/domain';
+import { generateProfile, UserFixture } from '@khlug/__test__/fixtures/domain';
 import { Message } from '@khlug/constant/message';
 
 describe('User', () => {
@@ -328,6 +328,11 @@ describe('User', () => {
         profile: generateProfile({ grade: params.grade ?? 1 }),
         createdAt: params.createdAt ?? new Date('2025-05-01'),
       });
+
+    test('정지 상태인 경우 `false`를 반환해야 한다', () => {
+      const user = UserFixture.stopped();
+      expect(user.needPayFee()).toEqual(false);
+    });
 
     test('재학 중이 아닌 경우 `false`를 반환해야 한다', () => {
       const user = createUser({ studentStatus: StudentStatus.GRADUATE });

--- a/src/app/domain/user/model/User.ts
+++ b/src/app/domain/user/model/User.ts
@@ -26,6 +26,7 @@ import {
 import { Profile } from '@khlug/app/domain/user/model/Profile';
 
 import { Message } from '@khlug/constant/message';
+import { UnivPeriod } from '@khlug/util/univPeriod';
 
 export type UserConstructorParams = {
   id: number;
@@ -243,7 +244,7 @@ export class User extends AggregateRoot {
 
   /**
    * 회비 납부 대상 여부
-   * @see 회비에 관한 세부 회칙 제2조
+   * @see 회비에 관한 세부 회칙 제2조, 제5조
    */
   needPayFee(): boolean {
     // 정지 상태의 회원은 회비 납부 대상이 아닙니다.
@@ -261,12 +262,25 @@ export class User extends AggregateRoot {
       return false;
     }
 
-    const joinedYears = dayjs().diff(this._createdAt, 'year');
+    let passedMinNeedPayFee = false;
 
-    const isJoinedYearsLessThanOne = joinedYears < 1;
+    const nowPeriod = UnivPeriod.fromDate(this._createdAt);
+    const thisSemester = UnivPeriod.fromDate(new Date()).toSemester();
+    if (nowPeriod.inVacation()) {
+      // 방학 중에 가입했다면, 다음 학기와 다다음 학기의 종강일을 지나야 2번의 종강일을 지남.
+      // ex) 2024년 겨울방학에 가입했다면 2024년 2학기로 보므로, 2025년 1학기와 2025년 2학기를 지나야 함.
+      const leastNeedPayTerm = nowPeriod.toSemester().next().next();
+      passedMinNeedPayFee = thisSemester.isAfter(leastNeedPayTerm);
+    } else {
+      // 학기 중에 가입했다면, 다음 학기의 종강일을 지나야 2번의 종강일을 지남.
+      // ex) 2024년 2학기에 가입했다면, 2024년 2학기와 2025년 1학기를 지나야 함.
+      const leastNeedPayTerm = nowPeriod.toSemester().next();
+      passedMinNeedPayFee = thisSemester.isAfter(leastNeedPayTerm);
+    }
+
     const isGradeLessThanFour = this._profile.grade < 4;
 
-    return isJoinedYearsLessThanOne || isGradeLessThanFour;
+    return !passedMinNeedPayFee || isGradeLessThanFour;
   }
 
   get id(): number {

--- a/src/app/domain/user/model/User.ts
+++ b/src/app/domain/user/model/User.ts
@@ -261,19 +261,12 @@ export class User extends AggregateRoot {
       return false;
     }
 
-    // 4학년이면 회비 납부 대상이 아닙니다.
-    if (this._profile.grade >= 4) {
-      return false;
-    }
+    const joinedYears = dayjs().diff(this._createdAt, 'year');
 
-    // 등록한지 309일이 안 된 경우 회비 납부 대상이 아닙니다.
-    // 이때, 309일은 방학을 제외한 1년입니다.
-    const joinedDays = dayjs().diff(this._createdAt, 'days');
-    if (joinedDays < 309) {
-      return false;
-    }
+    const isJoinedYearsLessThanOne = joinedYears < 1;
+    const isGradeLessThanFour = this._profile.grade < 4;
 
-    return true;
+    return isJoinedYearsLessThanOne || isGradeLessThanFour;
   }
 
   get id(): number {

--- a/src/app/domain/user/model/User.ts
+++ b/src/app/domain/user/model/User.ts
@@ -241,8 +241,16 @@ export class User extends AggregateRoot {
     return isTarget && !authedInThisSemester;
   }
 
-  // 회비 납부 대상 여부
+  /**
+   * 회비 납부 대상 여부
+   * @see 회비에 관한 세부 회칙 제2조
+   */
   needPayFee(): boolean {
+    // 정지 상태의 회원은 회비 납부 대상이 아닙니다.
+    if (this.isStopped()) {
+      return false;
+    }
+
     // 재학 중이 아니면 회비 납부 대상이 아닙니다.
     if (this._studentStatus !== StudentStatus.UNDERGRADUATE) {
       return false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import cookieParser from 'cookie-parser';
 import dayjs from 'dayjs';
+import isBetween from 'dayjs/plugin/isBetween';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 
@@ -13,6 +14,7 @@ import { RootModule } from '@khlug/RootModule';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
+dayjs.extend(isBetween);
 
 async function bootstrap() {
   const app = await NestFactory.create(RootModule);

--- a/src/util/univDate.spec.ts
+++ b/src/util/univDate.spec.ts
@@ -1,23 +1,20 @@
 import dayjs from 'dayjs';
 
 import { UnivDate } from '@khlug/util/univDate';
+import { UnivTerm } from '@khlug/util/univTerm';
 
 describe('UnivDate', () => {
   describe('calcSemesterStartDate', () => {
     test('1학기라면 3월 1일을 반환해야 한다', () => {
-      const year = 2025;
-      const semester = 1;
-
-      const result = UnivDate.calcSemesterStartDate(year, semester);
+      const term = new UnivTerm(2025, 1);
+      const result = UnivDate.calcSemesterStartDate(term);
 
       expect(result).toEqual(dayjs.tz('2025-03-01', 'Asia/Seoul').toDate());
     });
 
     test('2학기라면 9월 1일을 반환해야 한다', () => {
-      const year = 2025;
-      const semester = 2;
-
-      const result = UnivDate.calcSemesterStartDate(year, semester);
+      const term = new UnivTerm(2025, 2);
+      const result = UnivDate.calcSemesterStartDate(term);
 
       expect(result).toEqual(dayjs.tz('2025-09-01', 'Asia/Seoul').toDate());
     });
@@ -25,10 +22,8 @@ describe('UnivDate', () => {
 
   describe('calcMidTermExamEndDate', () => {
     test('1학기라면 3월 1일로부터 8주 후의 전날을 반환해야 한다', () => {
-      const year = 2025;
-      const semester = 1;
-
-      const result = UnivDate.calcMidTermExamEndDate(year, semester);
+      const term = new UnivTerm(2025, 1);
+      const result = UnivDate.calcMidTermExamEndDate(term);
 
       // o--------------------o   o--------------------o
       // |      2025-03       |   |      2025-04       |
@@ -45,10 +40,8 @@ describe('UnivDate', () => {
     });
 
     test('2학기라면 9월 1일로부터 8주 후의 전날을 반환해야 한다', () => {
-      const year = 2025;
-      const semester = 2;
-
-      const result = UnivDate.calcMidTermExamEndDate(year, semester);
+      const term = new UnivTerm(2025, 2);
+      const result = UnivDate.calcMidTermExamEndDate(term);
 
       // o--------------------o   o--------------------o
       // |      2025-09       |   |      2025-10       |
@@ -66,10 +59,8 @@ describe('UnivDate', () => {
 
   describe('calcFinalExamEndDate', () => {
     test('1학기라면 3월 1일로부터 16주 후의 전날을 반환해야 한다', () => {
-      const year = 2025;
-      const semester = 1;
-
-      const result = UnivDate.calcFinalExamEndDate(year, semester);
+      const term = new UnivTerm(2025, 1);
+      const result = UnivDate.calcFinalExamEndDate(term);
 
       // o--------------------o   o--------------------o
       // |      2025-03       |   |      2025-06       |
@@ -86,10 +77,8 @@ describe('UnivDate', () => {
     });
 
     test('2학기라면 9월 1일로부터 16주 후의 전날을 반환해야 한다', () => {
-      const year = 2025;
-      const semester = 2;
-
-      const result = UnivDate.calcFinalExamEndDate(year, semester);
+      const term = new UnivTerm(2025, 2);
+      const result = UnivDate.calcFinalExamEndDate(term);
 
       // o--------------------o   o--------------------o
       // |      2025-09       |   |      2025-12       |
@@ -107,28 +96,22 @@ describe('UnivDate', () => {
 
   describe('calcSemesterEndDate', () => {
     test('1학기라면 2학기 개강일의 전날을 반환해야 한다', () => {
-      const year = 2025;
-      const semester = 1;
-
-      const result = UnivDate.calcSemesterEndDate(year, semester);
+      const term = new UnivTerm(2025, 1);
+      const result = UnivDate.calcSemesterEndDate(term);
 
       expect(result).toEqual(dayjs.tz('2025-08-31', 'Asia/Seoul').toDate());
     });
 
     test('2학기라면 내년 1학기 개강일의 전날을 반환해야 한다', () => {
-      const year = 2025;
-      const semester = 2;
-
-      const result = UnivDate.calcSemesterEndDate(year, semester);
+      const term = new UnivTerm(2025, 2);
+      const result = UnivDate.calcSemesterEndDate(term);
 
       expect(result).toEqual(dayjs.tz('2026-02-28', 'Asia/Seoul').toDate());
     });
 
-    test('윤년이라면 29일을 반환해야 한다', () => {
-      const year = 2027;
-      const semester = 2;
-
-      const result = UnivDate.calcSemesterEndDate(year, semester);
+    test('2학기인데 내년이 윤년이라면 29일을 반환해야 한다', () => {
+      const term = new UnivTerm(2027, 2);
+      const result = UnivDate.calcSemesterEndDate(term);
 
       expect(result).toEqual(dayjs.tz('2028-02-29', 'Asia/Seoul').toDate());
     });

--- a/src/util/univDate.spec.ts
+++ b/src/util/univDate.spec.ts
@@ -1,0 +1,136 @@
+import dayjs from 'dayjs';
+
+import { UnivDate } from '@khlug/util/univDate';
+
+describe('UnivDate', () => {
+  describe('calcSemesterStartDate', () => {
+    test('1학기라면 3월 1일을 반환해야 한다', () => {
+      const year = 2025;
+      const semester = 1;
+
+      const result = UnivDate.calcSemesterStartDate(year, semester);
+
+      expect(result).toEqual(dayjs.tz('2025-03-01', 'Asia/Seoul').toDate());
+    });
+
+    test('2학기라면 9월 1일을 반환해야 한다', () => {
+      const year = 2025;
+      const semester = 2;
+
+      const result = UnivDate.calcSemesterStartDate(year, semester);
+
+      expect(result).toEqual(dayjs.tz('2025-09-01', 'Asia/Seoul').toDate());
+    });
+  });
+
+  describe('calcMidTermExamEndDate', () => {
+    test('1학기라면 3월 1일로부터 8주 후의 전날을 반환해야 한다', () => {
+      const year = 2025;
+      const semester = 1;
+
+      const result = UnivDate.calcMidTermExamEndDate(year, semester);
+
+      // o--------------------o   o--------------------o
+      // |      2025-03       |   |      2025-04       |
+      // |--------------------|   |--------------------|
+      // |  |  |  |  |  |  | 1|   |  |  | 1| 2| 3| 4| 5|
+      // | 2| 3| 4| 5| 6| 7| 8|   | 6| 7| 8| 9|10|11|12|
+      // | 9|10|11|12|13|14|15|   |13|14|15|16|17|18|19|
+      // |16|17|18|19|20|21|22|   |20|21|22|23|24|25|26|
+      // |23|24|25|26|27|28|29|   |27|28|29|30|  |  |  |
+      // |30|31|  |  |  |  |  |   o--------------------o
+      // o--------------------o
+      // 3월 1일은 일요일이고, 8주 후는 4월 26일이므로, 반환값은 4월 25일이어야 합니다.
+      expect(result).toEqual(dayjs.tz('2025-04-25', 'Asia/Seoul').toDate());
+    });
+
+    test('2학기라면 9월 1일로부터 8주 후의 전날을 반환해야 한다', () => {
+      const year = 2025;
+      const semester = 2;
+
+      const result = UnivDate.calcMidTermExamEndDate(year, semester);
+
+      // o--------------------o   o--------------------o
+      // |      2025-09       |   |      2025-10       |
+      // |--------------------|   |--------------------|
+      // |  | 1| 2| 3| 4| 5| 6|   |  |  |  | 1| 2| 3| 4|
+      // | 7| 8| 9|10|11|12|13|   | 5| 6| 7| 8| 9|10|11|
+      // |14|15|16|17|18|19|20|   |12|13|14|15|16|17|18|
+      // |21|22|23|24|25|26|27|   |19|20|21|22|23|24|25|
+      // |28|29|30|  |  |  |  |   |26|27|28|29|30|  |  |
+      // o--------------------o   o--------------------o
+      // 9월 1일은 월요일이고, 8주 후는 10월 27일이므로, 반환값은 10월 26일이어야 합니다.
+      expect(result).toEqual(dayjs.tz('2025-10-26', 'Asia/Seoul').toDate());
+    });
+  });
+
+  describe('calcFinalExamEndDate', () => {
+    test('1학기라면 3월 1일로부터 16주 후의 전날을 반환해야 한다', () => {
+      const year = 2025;
+      const semester = 1;
+
+      const result = UnivDate.calcFinalExamEndDate(year, semester);
+
+      // o--------------------o   o--------------------o
+      // |      2025-03       |   |      2025-06       |
+      // |--------------------|   |--------------------|
+      // |  |  |  |  |  |  | 1|   | 1| 2| 3| 4| 5| 6| 7|
+      // | 2| 3| 4| 5| 6| 7| 8|   | 8| 9|10|11|12|13|14|
+      // | 9|10|11|12|13|14|15|   |15|16|17|18|19|20|21|
+      // |16|17|18|19|20|21|22|   |22|23|24|25|26|27|28|
+      // |23|24|25|26|27|28|29|   |29|30|  |  |  |  |  |
+      // |30|31|  |  |  |  |  |   o--------------------o
+      // o--------------------o
+      // 3월 1일은 일요일이고, 16주 후는 6월 21일이므로, 반환값은 6월 20일이어야 합니다.
+      expect(result).toEqual(dayjs.tz('2025-06-20', 'Asia/Seoul').toDate());
+    });
+
+    test('2학기라면 9월 1일로부터 16주 후의 전날을 반환해야 한다', () => {
+      const year = 2025;
+      const semester = 2;
+
+      const result = UnivDate.calcFinalExamEndDate(year, semester);
+
+      // o--------------------o   o--------------------o
+      // |      2025-09       |   |      2025-12       |
+      // |--------------------|   |--------------------|
+      // |  | 1| 2| 3| 4| 5| 6|   |  | 1| 2| 3| 4| 5| 6|
+      // | 7| 8| 9|10|11|12|13|   | 7| 8| 9|10|11|12|13|
+      // |14|15|16|17|18|19|20|   |14|15|16|17|18|19|20|
+      // |21|22|23|24|25|26|27|   |21|22|23|24|25|26|27|
+      // |28|29|30|  |  |  |  |   |28|29|30|31|  |  |  |
+      // o--------------------o   o--------------------o
+      // 9월 1일은 월요일이고, 16주 후는 12월 22일이므로, 반환값은 12월 21일이어야 합니다.
+      expect(result).toEqual(dayjs.tz('2025-12-21', 'Asia/Seoul').toDate());
+    });
+  });
+
+  describe('calcSemesterEndDate', () => {
+    test('1학기라면 2학기 개강일의 전날을 반환해야 한다', () => {
+      const year = 2025;
+      const semester = 1;
+
+      const result = UnivDate.calcSemesterEndDate(year, semester);
+
+      expect(result).toEqual(dayjs.tz('2025-08-31', 'Asia/Seoul').toDate());
+    });
+
+    test('2학기라면 내년 1학기 개강일의 전날을 반환해야 한다', () => {
+      const year = 2025;
+      const semester = 2;
+
+      const result = UnivDate.calcSemesterEndDate(year, semester);
+
+      expect(result).toEqual(dayjs.tz('2026-02-28', 'Asia/Seoul').toDate());
+    });
+
+    test('윤년이라면 29일을 반환해야 한다', () => {
+      const year = 2027;
+      const semester = 2;
+
+      const result = UnivDate.calcSemesterEndDate(year, semester);
+
+      expect(result).toEqual(dayjs.tz('2028-02-29', 'Asia/Seoul').toDate());
+    });
+  });
+});

--- a/src/util/univDate.ts
+++ b/src/util/univDate.ts
@@ -1,0 +1,69 @@
+import dayjs from 'dayjs';
+
+export class UnivDate {
+  /**
+   * 주어진 연도 학기의 개강일을 계산합니다.
+   */
+  static calcSemesterStartDate(year: number, semester: 1 | 2): Date {
+    if (semester === 1) {
+      return dayjs.tz(`${year}-03-01`, 'Asia/Seoul').toDate();
+    } else {
+      return dayjs.tz(`${year}-09-01`, 'Asia/Seoul').toDate();
+    }
+  }
+
+  /**
+   * 주어진 연도 학기의 중간고사 완료 기준일을 계산합니다.
+   */
+  static calcMidTermExamEndDate(year: number, semester: 1 | 2): Date {
+    if (semester === 1) {
+      return dayjs
+        .tz(`${year}-03-01`, 'Asia/Seoul')
+        .add(8, 'week')
+        .subtract(1, 'day')
+        .toDate();
+    } else {
+      return dayjs
+        .tz(`${year}-09-01`, 'Asia/Seoul')
+        .add(8, 'week')
+        .subtract(1, 'day')
+        .toDate();
+    }
+  }
+
+  /**
+   * 주어진 연도 학기의 기말고사 완료 기준일(=종강일)을 계산합니다.
+   */
+  static calcFinalExamEndDate(year: number, semester: 1 | 2): Date {
+    if (semester === 1) {
+      return dayjs
+        .tz(`${year}-03-01`, 'Asia/Seoul')
+        .add(16, 'week')
+        .subtract(1, 'day')
+        .toDate();
+    } else {
+      return dayjs
+        .tz(`${year}-09-01`, 'Asia/Seoul')
+        .add(16, 'week')
+        .subtract(1, 'day')
+        .toDate();
+    }
+  }
+
+  /**
+   * 주어진 연도 학기의 학기 종료일을 계산합니다.
+   */
+  static calcSemesterEndDate(year: number, semester: 1 | 2): Date {
+    if (semester === 1) {
+      return dayjs
+        .tz(`${year}-09-01`, 'Asia/Seoul')
+        .subtract(1, 'day')
+        .toDate();
+    } else {
+      return dayjs
+        .tz(`${year + 1}-03-01`, 'Asia/Seoul')
+        .subtract(1, 'day')
+        .toDate();
+    }
+  }
+}

--- a/src/util/univDate.ts
+++ b/src/util/univDate.ts
@@ -1,10 +1,12 @@
 import dayjs from 'dayjs';
 
+import { UnivTerm } from '@khlug/util/univTerm';
+
 export class UnivDate {
   /**
    * 주어진 연도 학기의 개강일을 계산합니다.
    */
-  static calcSemesterStartDate(year: number, semester: 1 | 2): Date {
+  static calcSemesterStartDate({ year, semester }: UnivTerm): Date {
     if (semester === 1) {
       return dayjs.tz(`${year}-03-01`, 'Asia/Seoul').toDate();
     } else {
@@ -15,7 +17,7 @@ export class UnivDate {
   /**
    * 주어진 연도 학기의 중간고사 완료 기준일을 계산합니다.
    */
-  static calcMidTermExamEndDate(year: number, semester: 1 | 2): Date {
+  static calcMidTermExamEndDate({ year, semester }: UnivTerm): Date {
     if (semester === 1) {
       return dayjs
         .tz(`${year}-03-01`, 'Asia/Seoul')
@@ -34,7 +36,7 @@ export class UnivDate {
   /**
    * 주어진 연도 학기의 기말고사 완료 기준일(=종강일)을 계산합니다.
    */
-  static calcFinalExamEndDate(year: number, semester: 1 | 2): Date {
+  static calcFinalExamEndDate({ year, semester }: UnivTerm): Date {
     if (semester === 1) {
       return dayjs
         .tz(`${year}-03-01`, 'Asia/Seoul')
@@ -53,7 +55,7 @@ export class UnivDate {
   /**
    * 주어진 연도 학기의 학기 종료일을 계산합니다.
    */
-  static calcSemesterEndDate(year: number, semester: 1 | 2): Date {
+  static calcSemesterEndDate({ year, semester }: UnivTerm): Date {
     if (semester === 1) {
       return dayjs
         .tz(`${year}-09-01`, 'Asia/Seoul')

--- a/src/util/univPeriod.spec.ts
+++ b/src/util/univPeriod.spec.ts
@@ -7,6 +7,26 @@ describe('univPeriod', () => {
     const createKstDate = (dateStr: string) =>
       dayjs.tz(dateStr, 'Asia/Seoul').startOf('day');
 
+    describe('inVacation', () => {
+      test.each([
+        UnivPeriodType.FIRST_SEMESTER_MIDTERM_EXAM,
+        UnivPeriodType.FIRST_SEMESTER_FINAL_EXAM,
+        UnivPeriodType.SECOND_SEMESTER_MIDTERM_EXAM,
+        UnivPeriodType.SECOND_SEMESTER_FINAL_EXAM,
+      ])('학기 중이라면 `false`를 반환해야 한다', (type) => {
+        const period = new UnivPeriod(2025, type);
+        expect(period.inVacation()).toBe(false);
+      });
+
+      test.each([
+        UnivPeriodType.SUMMER_VACATION,
+        UnivPeriodType.WINTER_VACATION,
+      ])('방학 중이라면 `true`를 반환해야 한다', (type) => {
+        const period = new UnivPeriod(2025, type);
+        expect(period.inVacation()).toBe(true);
+      });
+    });
+
     describe('fromDate', () => {
       test('1학기가 시작하지 않았다면 전년도 겨울방학 기간을 반환해야 한다', () => {
         const date = createKstDate('2025-02-28').toDate();

--- a/src/util/univPeriod.spec.ts
+++ b/src/util/univPeriod.spec.ts
@@ -1,0 +1,114 @@
+import dayjs from 'dayjs';
+
+import { calcUnivPeriod, UnivPeriodType } from '@khlug/util/univPeriod';
+
+describe('semester', () => {
+  describe('calcUnivPeriod', () => {
+    const createKstDate = (dateStr: string) =>
+      dayjs.tz(dateStr, 'Asia/Seoul').startOf('day');
+
+    test('1학기가 시작하지 않았다면 전년도 겨울방학 기간을 반환해야 한다', () => {
+      const date = createKstDate('2025-02-28').toDate();
+      const result = calcUnivPeriod(date);
+
+      expect(result).toEqual({
+        year: 2024,
+        type: UnivPeriodType.WINTER_VACATION,
+      });
+    });
+
+    test('1학기가 시작하지 않았다면 전년도 겨울방학 기간을 반환해야 한다 (윤년)', () => {
+      const date = createKstDate('2024-02-29').toDate();
+      const result = calcUnivPeriod(date);
+
+      expect(result).toEqual({
+        year: 2023,
+        type: UnivPeriodType.WINTER_VACATION,
+      });
+    });
+
+    test.each([
+      createKstDate('2025-03-01').toDate(),
+      createKstDate('2025-03-01').add(4, 'week').toDate(),
+      createKstDate('2025-03-01').add(8, 'week').subtract(1, 'day').toDate(),
+    ])(
+      '1학기 개강일과 1학기 중간고사 종료 기준일 사이라면 1학기 중간고사 기간을 반환해야 한다',
+      (date: Date) => {
+        expect(calcUnivPeriod(date)).toEqual({
+          year: 2025,
+          type: UnivPeriodType.FIRST_SEMESTER_IN_MIDTERM_EXAM,
+        });
+      },
+    );
+
+    test.each([
+      createKstDate('2025-03-01').add(8, 'week').toDate(),
+      createKstDate('2025-03-01').add(12, 'week').toDate(),
+      createKstDate('2025-03-01').add(16, 'week').subtract(1, 'day').toDate(),
+    ])(
+      '1학기 중간고사 종료 기준일의 익일과 1학기 종강일 사이라면 1학기 기말고사 기간을 반환해야 한다',
+      (date: Date) => {
+        expect(calcUnivPeriod(date)).toEqual({
+          year: 2025,
+          type: UnivPeriodType.FIRST_SEMESTER_IN_FINAL_EXAM,
+        });
+      },
+    );
+
+    test.each([
+      createKstDate('2025-03-01').add(16, 'week').toDate(),
+      createKstDate('2025-03-01').add(20, 'week').toDate(),
+      createKstDate('2025-09-01').subtract(1, 'day').toDate(),
+    ])(
+      '1학기 종강일의 익일과 1학기 종료일 사이라면 여름 방학 기간을 반환해야 한다',
+      (date: Date) => {
+        expect(calcUnivPeriod(date)).toEqual({
+          year: 2025,
+          type: UnivPeriodType.SUMMER_VACATION,
+        });
+      },
+    );
+
+    test.each([
+      createKstDate('2025-09-01').toDate(),
+      createKstDate('2025-09-01').add(4, 'week').toDate(),
+      createKstDate('2025-09-01').add(8, 'week').subtract(1, 'day').toDate(),
+    ])(
+      '2학기 개강일과 2학기 중간고사 종료 기준일 사이라면 2학기 중간고사 기간을 반환해야 한다',
+      (date: Date) => {
+        expect(calcUnivPeriod(date)).toEqual({
+          year: 2025,
+          type: UnivPeriodType.SECOND_SEMESTER_IN_MIDTERM_EXAM,
+        });
+      },
+    );
+
+    test.each([
+      createKstDate('2025-09-01').add(8, 'week').toDate(),
+      createKstDate('2025-09-01').add(12, 'week').toDate(),
+      createKstDate('2025-09-01').add(16, 'week').subtract(1, 'day').toDate(),
+    ])(
+      '2학기 중간고사 종료 기준일의 익일과 2학기 종강일 사이라면 2학기 기말고사 기간을 반환해야 한다',
+      (date: Date) => {
+        expect(calcUnivPeriod(date)).toEqual({
+          year: 2025,
+          type: UnivPeriodType.SECOND_SEMESTER_IN_FINAL_EXAM,
+        });
+      },
+    );
+
+    test.each([
+      createKstDate('2025-09-01').add(16, 'week').toDate(),
+      createKstDate('2025-09-01').add(20, 'week').toDate(),
+      createKstDate('2025-12-31').toDate(),
+    ])(
+      '2학기 종강일의 익일과 연의 말일 사이라면 겨울 방학 기간을 반환해야 한다',
+      (date: Date) => {
+        expect(calcUnivPeriod(date)).toEqual({
+          year: 2025,
+          type: UnivPeriodType.WINTER_VACATION,
+        });
+      },
+    );
+  });
+});

--- a/src/util/univPeriod.spec.ts
+++ b/src/util/univPeriod.spec.ts
@@ -1,114 +1,108 @@
 import dayjs from 'dayjs';
 
-import { calcUnivPeriod, UnivPeriodType } from '@khlug/util/univPeriod';
+import { UnivPeriod, UnivPeriodType } from '@khlug/util/univPeriod';
 
-describe('semester', () => {
-  describe('calcUnivPeriod', () => {
+describe('univPeriod', () => {
+  describe('UnivPeriod', () => {
     const createKstDate = (dateStr: string) =>
       dayjs.tz(dateStr, 'Asia/Seoul').startOf('day');
 
-    test('1학기가 시작하지 않았다면 전년도 겨울방학 기간을 반환해야 한다', () => {
-      const date = createKstDate('2025-02-28').toDate();
-      const result = calcUnivPeriod(date);
+    describe('fromDate', () => {
+      test('1학기가 시작하지 않았다면 전년도 겨울방학 기간을 반환해야 한다', () => {
+        const date = createKstDate('2025-02-28').toDate();
+        const result = UnivPeriod.fromDate(date);
 
-      expect(result).toEqual({
-        year: 2024,
-        type: UnivPeriodType.WINTER_VACATION,
+        expect(result).toEqual(
+          new UnivPeriod(2024, UnivPeriodType.WINTER_VACATION),
+        );
       });
-    });
 
-    test('1학기가 시작하지 않았다면 전년도 겨울방학 기간을 반환해야 한다 (윤년)', () => {
-      const date = createKstDate('2024-02-29').toDate();
-      const result = calcUnivPeriod(date);
+      test('1학기가 시작하지 않았다면 전년도 겨울방학 기간을 반환해야 한다 (윤년)', () => {
+        const date = createKstDate('2024-02-29').toDate();
+        const result = UnivPeriod.fromDate(date);
 
-      expect(result).toEqual({
-        year: 2023,
-        type: UnivPeriodType.WINTER_VACATION,
+        expect(result).toEqual(
+          new UnivPeriod(2023, UnivPeriodType.WINTER_VACATION),
+        );
       });
+
+      test.each([
+        createKstDate('2025-03-01').toDate(),
+        createKstDate('2025-03-01').add(4, 'week').toDate(),
+        createKstDate('2025-03-01').add(8, 'week').subtract(1, 'day').toDate(),
+      ])(
+        '1학기 개강일과 1학기 중간고사 종료 기준일 사이라면 1학기 중간고사 기간을 반환해야 한다',
+        (date: Date) => {
+          expect(UnivPeriod.fromDate(date)).toEqual(
+            new UnivPeriod(2025, UnivPeriodType.FIRST_SEMESTER_MIDTERM_EXAM),
+          );
+        },
+      );
+
+      test.each([
+        createKstDate('2025-03-01').add(8, 'week').toDate(),
+        createKstDate('2025-03-01').add(12, 'week').toDate(),
+        createKstDate('2025-03-01').add(16, 'week').subtract(1, 'day').toDate(),
+      ])(
+        '1학기 중간고사 종료 기준일의 익일과 1학기 종강일 사이라면 1학기 기말고사 기간을 반환해야 한다',
+        (date: Date) => {
+          expect(UnivPeriod.fromDate(date)).toEqual(
+            new UnivPeriod(2025, UnivPeriodType.FIRST_SEMESTER_FINAL_EXAM),
+          );
+        },
+      );
+
+      test.each([
+        createKstDate('2025-03-01').add(16, 'week').toDate(),
+        createKstDate('2025-03-01').add(20, 'week').toDate(),
+        createKstDate('2025-09-01').subtract(1, 'day').toDate(),
+      ])(
+        '1학기 종강일의 익일과 1학기 종료일 사이라면 여름 방학 기간을 반환해야 한다',
+        (date: Date) => {
+          expect(UnivPeriod.fromDate(date)).toEqual(
+            new UnivPeriod(2025, UnivPeriodType.SUMMER_VACATION),
+          );
+        },
+      );
+
+      test.each([
+        createKstDate('2025-09-01').toDate(),
+        createKstDate('2025-09-01').add(4, 'week').toDate(),
+        createKstDate('2025-09-01').add(8, 'week').subtract(1, 'day').toDate(),
+      ])(
+        '2학기 개강일과 2학기 중간고사 종료 기준일 사이라면 2학기 중간고사 기간을 반환해야 한다',
+        (date: Date) => {
+          expect(UnivPeriod.fromDate(date)).toEqual(
+            new UnivPeriod(2025, UnivPeriodType.SECOND_SEMESTER_MIDTERM_EXAM),
+          );
+        },
+      );
+
+      test.each([
+        createKstDate('2025-09-01').add(8, 'week').toDate(),
+        createKstDate('2025-09-01').add(12, 'week').toDate(),
+        createKstDate('2025-09-01').add(16, 'week').subtract(1, 'day').toDate(),
+      ])(
+        '2학기 중간고사 종료 기준일의 익일과 2학기 종강일 사이라면 2학기 기말고사 기간을 반환해야 한다',
+        (date: Date) => {
+          expect(UnivPeriod.fromDate(date)).toEqual(
+            new UnivPeriod(2025, UnivPeriodType.SECOND_SEMESTER_FINAL_EXAM),
+          );
+        },
+      );
+
+      test.each([
+        createKstDate('2025-09-01').add(16, 'week').toDate(),
+        createKstDate('2025-09-01').add(20, 'week').toDate(),
+        createKstDate('2025-12-31').toDate(),
+      ])(
+        '2학기 종강일의 익일과 연의 말일 사이라면 겨울 방학 기간을 반환해야 한다',
+        (date: Date) => {
+          expect(UnivPeriod.fromDate(date)).toEqual(
+            new UnivPeriod(2025, UnivPeriodType.WINTER_VACATION),
+          );
+        },
+      );
     });
-
-    test.each([
-      createKstDate('2025-03-01').toDate(),
-      createKstDate('2025-03-01').add(4, 'week').toDate(),
-      createKstDate('2025-03-01').add(8, 'week').subtract(1, 'day').toDate(),
-    ])(
-      '1학기 개강일과 1학기 중간고사 종료 기준일 사이라면 1학기 중간고사 기간을 반환해야 한다',
-      (date: Date) => {
-        expect(calcUnivPeriod(date)).toEqual({
-          year: 2025,
-          type: UnivPeriodType.FIRST_SEMESTER_IN_MIDTERM_EXAM,
-        });
-      },
-    );
-
-    test.each([
-      createKstDate('2025-03-01').add(8, 'week').toDate(),
-      createKstDate('2025-03-01').add(12, 'week').toDate(),
-      createKstDate('2025-03-01').add(16, 'week').subtract(1, 'day').toDate(),
-    ])(
-      '1학기 중간고사 종료 기준일의 익일과 1학기 종강일 사이라면 1학기 기말고사 기간을 반환해야 한다',
-      (date: Date) => {
-        expect(calcUnivPeriod(date)).toEqual({
-          year: 2025,
-          type: UnivPeriodType.FIRST_SEMESTER_IN_FINAL_EXAM,
-        });
-      },
-    );
-
-    test.each([
-      createKstDate('2025-03-01').add(16, 'week').toDate(),
-      createKstDate('2025-03-01').add(20, 'week').toDate(),
-      createKstDate('2025-09-01').subtract(1, 'day').toDate(),
-    ])(
-      '1학기 종강일의 익일과 1학기 종료일 사이라면 여름 방학 기간을 반환해야 한다',
-      (date: Date) => {
-        expect(calcUnivPeriod(date)).toEqual({
-          year: 2025,
-          type: UnivPeriodType.SUMMER_VACATION,
-        });
-      },
-    );
-
-    test.each([
-      createKstDate('2025-09-01').toDate(),
-      createKstDate('2025-09-01').add(4, 'week').toDate(),
-      createKstDate('2025-09-01').add(8, 'week').subtract(1, 'day').toDate(),
-    ])(
-      '2학기 개강일과 2학기 중간고사 종료 기준일 사이라면 2학기 중간고사 기간을 반환해야 한다',
-      (date: Date) => {
-        expect(calcUnivPeriod(date)).toEqual({
-          year: 2025,
-          type: UnivPeriodType.SECOND_SEMESTER_IN_MIDTERM_EXAM,
-        });
-      },
-    );
-
-    test.each([
-      createKstDate('2025-09-01').add(8, 'week').toDate(),
-      createKstDate('2025-09-01').add(12, 'week').toDate(),
-      createKstDate('2025-09-01').add(16, 'week').subtract(1, 'day').toDate(),
-    ])(
-      '2학기 중간고사 종료 기준일의 익일과 2학기 종강일 사이라면 2학기 기말고사 기간을 반환해야 한다',
-      (date: Date) => {
-        expect(calcUnivPeriod(date)).toEqual({
-          year: 2025,
-          type: UnivPeriodType.SECOND_SEMESTER_IN_FINAL_EXAM,
-        });
-      },
-    );
-
-    test.each([
-      createKstDate('2025-09-01').add(16, 'week').toDate(),
-      createKstDate('2025-09-01').add(20, 'week').toDate(),
-      createKstDate('2025-12-31').toDate(),
-    ])(
-      '2학기 종강일의 익일과 연의 말일 사이라면 겨울 방학 기간을 반환해야 한다',
-      (date: Date) => {
-        expect(calcUnivPeriod(date)).toEqual({
-          year: 2025,
-          type: UnivPeriodType.WINTER_VACATION,
-        });
-      },
-    );
   });
 });

--- a/src/util/univPeriod.ts
+++ b/src/util/univPeriod.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 
 import { UnivDate } from '@khlug/util/univDate';
+import { UnivTerm } from '@khlug/util/univTerm';
 
 /**
  * 각 일자 기준에 대한 정의는 회비에 관한 세부 회칙 제8조를 참고해주세요.
@@ -43,6 +44,19 @@ export class UnivPeriod {
     );
   }
 
+  toSemester(): UnivTerm {
+    switch (this.type) {
+      case UnivPeriodType.FIRST_SEMESTER_MIDTERM_EXAM:
+      case UnivPeriodType.FIRST_SEMESTER_FINAL_EXAM:
+      case UnivPeriodType.SUMMER_VACATION:
+        return new UnivTerm(this.year, 1);
+      case UnivPeriodType.SECOND_SEMESTER_MIDTERM_EXAM:
+      case UnivPeriodType.SECOND_SEMESTER_FINAL_EXAM:
+      case UnivPeriodType.WINTER_VACATION:
+        return new UnivTerm(this.year, 2);
+    }
+  }
+
   /**
    * @see 회비에 관한 세부 회칙 제8조
    */
@@ -51,14 +65,16 @@ export class UnivPeriod {
 
     const year = dateInKst.year();
 
-    const firstStart = UnivDate.calcSemesterStartDate(year, 1);
-    const firstMidTermEnd = UnivDate.calcMidTermExamEndDate(year, 1);
-    const firstFinalEnd = UnivDate.calcFinalExamEndDate(year, 1);
-    const firstEnd = UnivDate.calcSemesterEndDate(year, 1);
+    const firstTerm = new UnivTerm(year, 1);
+    const firstStart = UnivDate.calcSemesterStartDate(firstTerm);
+    const firstMidTermEnd = UnivDate.calcMidTermExamEndDate(firstTerm);
+    const firstFinalEnd = UnivDate.calcFinalExamEndDate(firstTerm);
+    const firstEnd = UnivDate.calcSemesterEndDate(firstTerm);
 
-    const secondStart = UnivDate.calcSemesterStartDate(year, 2);
-    const secondMidTermEnd = UnivDate.calcMidTermExamEndDate(year, 2);
-    const secondFinalEnd = UnivDate.calcFinalExamEndDate(year, 2);
+    const secondTerm = new UnivTerm(year, 2);
+    const secondStart = UnivDate.calcSemesterStartDate(secondTerm);
+    const secondMidTermEnd = UnivDate.calcMidTermExamEndDate(secondTerm);
+    const secondFinalEnd = UnivDate.calcFinalExamEndDate(secondTerm);
 
     if (dateInKst.isBefore(firstStart)) {
       return new UnivPeriod(year - 1, UnivPeriodType.WINTER_VACATION);

--- a/src/util/univPeriod.ts
+++ b/src/util/univPeriod.ts
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs';
 
+import { UnivDate } from '@khlug/util/univDate';
+
 /**
  * 각 일자 기준에 대한 정의는 회비에 관한 세부 회칙 제8조를 참고해주세요.
  */
@@ -46,18 +48,17 @@ export class UnivPeriod {
    */
   static fromDate(refDate: Date): UnivPeriod {
     const dateInKst = dayjs.tz(refDate, 'Asia/Seoul').startOf('day');
-    const createKstDate = (dateStr: string) => dayjs.tz(dateStr, 'Asia/Seoul');
 
     const year = dateInKst.year();
 
-    const firstStart = createKstDate(`${year}-03-01`);
-    const firstMidTermEnd = firstStart.add(8, 'week').subtract(1, 'day');
-    const firstFinalEnd = firstStart.add(16, 'week').subtract(1, 'day');
-    const firstEnd = createKstDate(`${year}-09-01`).subtract(1, 'day');
+    const firstStart = UnivDate.calcSemesterStartDate(year, 1);
+    const firstMidTermEnd = UnivDate.calcMidTermExamEndDate(year, 1);
+    const firstFinalEnd = UnivDate.calcFinalExamEndDate(year, 1);
+    const firstEnd = UnivDate.calcSemesterEndDate(year, 1);
 
-    const secondStart = createKstDate(`${year}-09-01`);
-    const secondMidTermEnd = secondStart.add(8, 'week').subtract(1, 'day');
-    const secondFinalEnd = secondStart.add(16, 'week').subtract(1, 'day');
+    const secondStart = UnivDate.calcSemesterStartDate(year, 2);
+    const secondMidTermEnd = UnivDate.calcMidTermExamEndDate(year, 2);
+    const secondFinalEnd = UnivDate.calcFinalExamEndDate(year, 2);
 
     if (dateInKst.isBefore(firstStart)) {
       return new UnivPeriod(year - 1, UnivPeriodType.WINTER_VACATION);

--- a/src/util/univPeriod.ts
+++ b/src/util/univPeriod.ts
@@ -34,6 +34,13 @@ export class UnivPeriod {
     this.type = type;
   }
 
+  inVacation(): boolean {
+    return (
+      this.type === UnivPeriodType.SUMMER_VACATION ||
+      this.type === UnivPeriodType.WINTER_VACATION
+    );
+  }
+
   /**
    * @see 회비에 관한 세부 회칙 제8조
    */

--- a/src/util/univPeriod.ts
+++ b/src/util/univPeriod.ts
@@ -1,0 +1,76 @@
+import dayjs from 'dayjs';
+
+/**
+ * 각 일자 기준에 대한 정의는 회비에 관한 세부 회칙 제8조를 참고해주세요.
+ */
+export const UnivPeriodType = {
+  /** 1학기 개강일 ~ 1학기 중간고사 종료 기준일 */
+  FIRST_SEMESTER_IN_MIDTERM_EXAM: 1, //
+
+  /** 1학기 중간고사 종료 기준일의 익일 ~ 1학기 종강일 */
+  FIRST_SEMESTER_IN_FINAL_EXAM: 2,
+
+  /** 1학기 종강일의 익일 ~ 1학기 종료일 */
+  SUMMER_VACATION: 3,
+
+  /** 2학기 개강일 ~ 2학기 중간고사 종료 기준일 */
+  SECOND_SEMESTER_IN_MIDTERM_EXAM: 4,
+
+  /** 2학기 중간고사 종료 기준일의 익일 ~ 2학기 종강일 */
+  SECOND_SEMESTER_IN_FINAL_EXAM: 5,
+
+  /** 2학기 종강일의 익일 ~ 2학기 종료일 */
+  WINTER_VACATION: 6,
+} as const;
+export type UnivPeriodType =
+  (typeof UnivPeriodType)[keyof typeof UnivPeriodType];
+
+export interface UnivPeriod {
+  readonly year: number;
+  readonly type: UnivPeriodType;
+}
+
+/**
+ * @see 회비에 관한 세부 회칙 제8조
+ */
+export function calcUnivPeriod(refDate: Date): UnivPeriod {
+  const dateInKst = dayjs.tz(refDate, 'Asia/Seoul').startOf('day');
+  const createKstDate = (dateStr: string) => dayjs.tz(dateStr, 'Asia/Seoul');
+
+  const year = dateInKst.year();
+
+  const firstStart = createKstDate(`${year}-03-01`);
+  const firstMidTermEnd = firstStart.add(8, 'week').subtract(1, 'day');
+  const firstFinalEnd = firstStart.add(16, 'week').subtract(1, 'day');
+  const firstEnd = createKstDate(`${year}-09-01`).subtract(1, 'day');
+
+  const secondStart = createKstDate(`${year}-09-01`);
+  const secondMidTermEnd = secondStart.add(8, 'week').subtract(1, 'day');
+  const secondFinalEnd = secondStart.add(16, 'week').subtract(1, 'day');
+
+  if (dateInKst.isBefore(firstStart)) {
+    return { year: year - 1, type: UnivPeriodType.WINTER_VACATION };
+  }
+
+  if (dateInKst.isBetween(firstStart, firstMidTermEnd, 'day', '[]')) {
+    return { year, type: UnivPeriodType.FIRST_SEMESTER_IN_MIDTERM_EXAM };
+  }
+
+  if (dateInKst.isBetween(firstMidTermEnd, firstFinalEnd, 'day', '[]')) {
+    return { year, type: UnivPeriodType.FIRST_SEMESTER_IN_FINAL_EXAM };
+  }
+
+  if (dateInKst.isBetween(firstFinalEnd, firstEnd, 'day', '[]')) {
+    return { year, type: UnivPeriodType.SUMMER_VACATION };
+  }
+
+  if (dateInKst.isBetween(secondStart, secondMidTermEnd, 'day', '[]')) {
+    return { year, type: UnivPeriodType.SECOND_SEMESTER_IN_MIDTERM_EXAM };
+  }
+
+  if (dateInKst.isBetween(secondMidTermEnd, secondFinalEnd, 'day', '[]')) {
+    return { year, type: UnivPeriodType.SECOND_SEMESTER_IN_FINAL_EXAM };
+  }
+
+  return { year, type: UnivPeriodType.WINTER_VACATION };
+}

--- a/src/util/univPeriod.ts
+++ b/src/util/univPeriod.ts
@@ -5,19 +5,19 @@ import dayjs from 'dayjs';
  */
 export const UnivPeriodType = {
   /** 1학기 개강일 ~ 1학기 중간고사 종료 기준일 */
-  FIRST_SEMESTER_IN_MIDTERM_EXAM: 1, //
+  FIRST_SEMESTER_MIDTERM_EXAM: 1, //
 
   /** 1학기 중간고사 종료 기준일의 익일 ~ 1학기 종강일 */
-  FIRST_SEMESTER_IN_FINAL_EXAM: 2,
+  FIRST_SEMESTER_FINAL_EXAM: 2,
 
   /** 1학기 종강일의 익일 ~ 1학기 종료일 */
   SUMMER_VACATION: 3,
 
   /** 2학기 개강일 ~ 2학기 중간고사 종료 기준일 */
-  SECOND_SEMESTER_IN_MIDTERM_EXAM: 4,
+  SECOND_SEMESTER_MIDTERM_EXAM: 4,
 
   /** 2학기 중간고사 종료 기준일의 익일 ~ 2학기 종강일 */
-  SECOND_SEMESTER_IN_FINAL_EXAM: 5,
+  SECOND_SEMESTER_FINAL_EXAM: 5,
 
   /** 2학기 종강일의 익일 ~ 2학기 종료일 */
   WINTER_VACATION: 6,
@@ -25,52 +25,57 @@ export const UnivPeriodType = {
 export type UnivPeriodType =
   (typeof UnivPeriodType)[keyof typeof UnivPeriodType];
 
-export interface UnivPeriod {
+export class UnivPeriod {
   readonly year: number;
   readonly type: UnivPeriodType;
-}
 
-/**
- * @see 회비에 관한 세부 회칙 제8조
- */
-export function calcUnivPeriod(refDate: Date): UnivPeriod {
-  const dateInKst = dayjs.tz(refDate, 'Asia/Seoul').startOf('day');
-  const createKstDate = (dateStr: string) => dayjs.tz(dateStr, 'Asia/Seoul');
-
-  const year = dateInKst.year();
-
-  const firstStart = createKstDate(`${year}-03-01`);
-  const firstMidTermEnd = firstStart.add(8, 'week').subtract(1, 'day');
-  const firstFinalEnd = firstStart.add(16, 'week').subtract(1, 'day');
-  const firstEnd = createKstDate(`${year}-09-01`).subtract(1, 'day');
-
-  const secondStart = createKstDate(`${year}-09-01`);
-  const secondMidTermEnd = secondStart.add(8, 'week').subtract(1, 'day');
-  const secondFinalEnd = secondStart.add(16, 'week').subtract(1, 'day');
-
-  if (dateInKst.isBefore(firstStart)) {
-    return { year: year - 1, type: UnivPeriodType.WINTER_VACATION };
+  constructor(year: number, type: UnivPeriodType) {
+    this.year = year;
+    this.type = type;
   }
 
-  if (dateInKst.isBetween(firstStart, firstMidTermEnd, 'day', '[]')) {
-    return { year, type: UnivPeriodType.FIRST_SEMESTER_IN_MIDTERM_EXAM };
-  }
+  /**
+   * @see 회비에 관한 세부 회칙 제8조
+   */
+  static fromDate(refDate: Date): UnivPeriod {
+    const dateInKst = dayjs.tz(refDate, 'Asia/Seoul').startOf('day');
+    const createKstDate = (dateStr: string) => dayjs.tz(dateStr, 'Asia/Seoul');
 
-  if (dateInKst.isBetween(firstMidTermEnd, firstFinalEnd, 'day', '[]')) {
-    return { year, type: UnivPeriodType.FIRST_SEMESTER_IN_FINAL_EXAM };
-  }
+    const year = dateInKst.year();
 
-  if (dateInKst.isBetween(firstFinalEnd, firstEnd, 'day', '[]')) {
-    return { year, type: UnivPeriodType.SUMMER_VACATION };
-  }
+    const firstStart = createKstDate(`${year}-03-01`);
+    const firstMidTermEnd = firstStart.add(8, 'week').subtract(1, 'day');
+    const firstFinalEnd = firstStart.add(16, 'week').subtract(1, 'day');
+    const firstEnd = createKstDate(`${year}-09-01`).subtract(1, 'day');
 
-  if (dateInKst.isBetween(secondStart, secondMidTermEnd, 'day', '[]')) {
-    return { year, type: UnivPeriodType.SECOND_SEMESTER_IN_MIDTERM_EXAM };
-  }
+    const secondStart = createKstDate(`${year}-09-01`);
+    const secondMidTermEnd = secondStart.add(8, 'week').subtract(1, 'day');
+    const secondFinalEnd = secondStart.add(16, 'week').subtract(1, 'day');
 
-  if (dateInKst.isBetween(secondMidTermEnd, secondFinalEnd, 'day', '[]')) {
-    return { year, type: UnivPeriodType.SECOND_SEMESTER_IN_FINAL_EXAM };
-  }
+    if (dateInKst.isBefore(firstStart)) {
+      return new UnivPeriod(year - 1, UnivPeriodType.WINTER_VACATION);
+    }
 
-  return { year, type: UnivPeriodType.WINTER_VACATION };
+    if (dateInKst.isBetween(firstStart, firstMidTermEnd, 'day', '[]')) {
+      return new UnivPeriod(year, UnivPeriodType.FIRST_SEMESTER_MIDTERM_EXAM);
+    }
+
+    if (dateInKst.isBetween(firstMidTermEnd, firstFinalEnd, 'day', '[]')) {
+      return new UnivPeriod(year, UnivPeriodType.FIRST_SEMESTER_FINAL_EXAM);
+    }
+
+    if (dateInKst.isBetween(firstFinalEnd, firstEnd, 'day', '[]')) {
+      return new UnivPeriod(year, UnivPeriodType.SUMMER_VACATION);
+    }
+
+    if (dateInKst.isBetween(secondStart, secondMidTermEnd, 'day', '[]')) {
+      return new UnivPeriod(year, UnivPeriodType.SECOND_SEMESTER_MIDTERM_EXAM);
+    }
+
+    if (dateInKst.isBetween(secondMidTermEnd, secondFinalEnd, 'day', '[]')) {
+      return new UnivPeriod(year, UnivPeriodType.SECOND_SEMESTER_FINAL_EXAM);
+    }
+
+    return new UnivPeriod(year, UnivPeriodType.WINTER_VACATION);
+  }
 }

--- a/src/util/univTerm.spec.ts
+++ b/src/util/univTerm.spec.ts
@@ -1,0 +1,25 @@
+import { UnivTerm } from '@khlug/util/univTerm';
+
+describe('UnivTerm', () => {
+  describe('next', () => {
+    test('1학기라면 동일 년도 2학기가 되어야 한다', () => {
+      const univTerm = new UnivTerm(2025, 1);
+
+      expect(univTerm.next()).toEqual(new UnivTerm(2025, 2));
+    });
+
+    test('2학기라면 다음 년도 1학기가 되어야 한다', () => {
+      const univTerm = new UnivTerm(2025, 2);
+
+      expect(univTerm.next()).toEqual(new UnivTerm(2026, 1));
+    });
+
+    test('기존 객체는 변경되지 않아야 한다', () => {
+      const univTerm = new UnivTerm(2025, 1);
+
+      univTerm.next();
+
+      expect(univTerm).toEqual(new UnivTerm(2025, 1));
+    });
+  });
+});

--- a/src/util/univTerm.spec.ts
+++ b/src/util/univTerm.spec.ts
@@ -22,4 +22,41 @@ describe('UnivTerm', () => {
       expect(univTerm).toEqual(new UnivTerm(2025, 1));
     });
   });
+
+  describe('isAfter', () => {
+    test('동일 년도 동일 학기라면 `false`를 반환해야 한다', () => {
+      const thisTerm = new UnivTerm(2025, 1);
+      const otherTerm = new UnivTerm(2025, 1);
+
+      expect(thisTerm.isAfter(otherTerm)).toBe(false);
+    });
+
+    test('동일 년도이고 본 객체의 학기가 크다면 `true`를 반환해야 한다', () => {
+      const thisTerm = new UnivTerm(2025, 2);
+      const otherTerm = new UnivTerm(2025, 1);
+
+      expect(thisTerm.isAfter(otherTerm)).toBe(true);
+    });
+
+    test('동일 년도이고 본 객체의 학기가 작다면 `false`를 반환해야 한다', () => {
+      const thisTerm = new UnivTerm(2025, 1);
+      const otherTerm = new UnivTerm(2025, 2);
+
+      expect(thisTerm.isAfter(otherTerm)).toBe(false);
+    });
+
+    test('본 객체의 년도가 크다면 `true`를 반환해야 한다', () => {
+      const thisTerm = new UnivTerm(2026, 1);
+      const otherTerm = new UnivTerm(2025, 2);
+
+      expect(thisTerm.isAfter(otherTerm)).toBe(true);
+    });
+
+    test('본 객체의 년도가 작다면 `false`를 반환해야 한다', () => {
+      const thisTerm = new UnivTerm(2025, 2);
+      const otherTerm = new UnivTerm(2026, 1);
+
+      expect(thisTerm.isAfter(otherTerm)).toBe(false);
+    });
+  });
 });

--- a/src/util/univTerm.ts
+++ b/src/util/univTerm.ts
@@ -12,4 +12,11 @@ export class UnivTerm {
     const nextSemester = this.semester === 2 ? 1 : 2;
     return new UnivTerm(nextYear, nextSemester);
   }
+
+  isAfter(other: UnivTerm): boolean {
+    return (
+      this.year > other.year ||
+      (this.year === other.year && this.semester > other.semester)
+    );
+  }
 }

--- a/src/util/univTerm.ts
+++ b/src/util/univTerm.ts
@@ -1,0 +1,15 @@
+export class UnivTerm {
+  year: number;
+  semester: 1 | 2;
+
+  constructor(year: number, semester: 1 | 2) {
+    this.year = year;
+    this.semester = semester;
+  }
+
+  next(): UnivTerm {
+    const nextYear = this.semester === 2 ? this.year + 1 : this.year;
+    const nextSemester = this.semester === 2 ? 1 : 2;
+    return new UnivTerm(nextYear, nextSemester);
+  }
+}


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

잘못된 회비 납부 대상 판단 로직을 수정하고 관련 테스트 케이스를 추가합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

`"가입한지 1년이 지나지 않았음" OR "4학년 미만임"`인 경우 납부 대상인데, 의도와 다르게 동작하고 있었습니다.
또, 방학 내 가입자에 대한 케이스 처리를 추가합니다.