### PR TITLE
fix: non-standard인 레거시 날짜 데이터를 처리할 수 있도록 수정

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,11 @@ services:
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+      # 레거시 데이터가 `0000-00-00 00:00:00`와 같은 non-standard 데이터를 갖고 있어,
+      # `NO_ZERO_IN_DATE`와 `NO_ZERO_DATE`를 `sql_mode`로부터 제외시킵니다.
+      # 사이트 시스템 마이그레이션이 완료된 뒤에는 제거해야 합니다.
+      # @see https://dev.mysql.com/doc/refman/8.4/en/server-system-variables.html#sysvar_sql_mode
+      - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
     volumes:
       - ./.mysql/:/docker-entrypoint-initdb.d
     healthcheck:

--- a/mikro-orm.config.ts
+++ b/mikro-orm.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from '@mikro-orm/mysql';
+import dayjs from 'dayjs';
+import isBetween from 'dayjs/plugin/isBetween';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
 
 import { EntityModels } from '@khlug/core/persistence/Entities';
+
+// mikro-orm CLI entrypoint 이므로 호출해주어야 정상적으로 실행될 수 있습니다.
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(isBetween);
 
 export default defineConfig({
   entities: EntityModels,

--- a/src/app/domain/user/model/Profile.ts
+++ b/src/app/domain/user/model/Profile.ts
@@ -30,7 +30,12 @@ export class Profile {
   readonly grade: number;
 
   // TODO: 현재는 숫자 컬럼인데 문자열 컬럼으로 수정해야 함
-  @Property({ type: 'int', name: 'number', nullable: true })
+  @Property({
+    columnType: 'bigint',
+    runtimeType: 'number',
+    name: 'number',
+    nullable: true,
+  })
   @IsInt()
   @IsOptional()
   readonly number: number | null;

--- a/src/app/domain/user/model/User.ts
+++ b/src/app/domain/user/model/User.ts
@@ -1,6 +1,7 @@
 import {
   Embedded,
   Entity,
+  IType,
   PrimaryKey,
   Property,
   Unique,
@@ -26,6 +27,7 @@ import {
 import { Profile } from '@khlug/app/domain/user/model/Profile';
 
 import { Message } from '@khlug/constant/message';
+import { LegacyDateConverter } from '@khlug/util/mikro-orm/LegacyDateConverter';
 import { UnivPeriod, UnivPeriodType } from '@khlug/util/univPeriod';
 
 export type UserConstructorParams = {
@@ -104,7 +106,11 @@ export class User extends AggregateRoot {
   @IsOptional()
   private _rememberToken: string | null;
 
-  @Property({ type: 'timestamp', name: 'khuisauth_at' })
+  @Property({
+    type: LegacyDateConverter,
+    columnType: 'timestamp',
+    name: 'khuisauth_at',
+  })
   @IsDate()
   private _khuisAuthAt: Date;
 
@@ -139,13 +145,21 @@ export class User extends AggregateRoot {
   @IsDate()
   private _createdAt: Date;
 
-  @Property({ type: 'timestamp', name: 'last_login' })
+  @Property({
+    type: LegacyDateConverter,
+    columnType: 'timestamp',
+    name: 'last_login',
+  })
   @IsDate()
   private _lastLoginAt: Date;
 
-  @Property({ type: 'timestamp', name: 'last_enter' })
+  @Property({
+    type: LegacyDateConverter,
+    columnType: 'timestamp',
+    name: 'last_enter',
+  })
   @IsDate()
-  private _lastEnterAt: Date;
+  private _lastEnterAt: IType<Date, string>;
 
   @Embedded(() => Profile, { prefix: '' })
   private _profile: Profile;

--- a/src/util/mikro-orm/LegacyDateConverter.ts
+++ b/src/util/mikro-orm/LegacyDateConverter.ts
@@ -1,0 +1,26 @@
+import { Type } from '@mikro-orm/core';
+
+const LEGACY_NON_STANDARD_DATE = '0000-00-00 00:00:00';
+
+// 레거시 데이터가 `0000-00-00 00:00:00`와 같은 non-standard 데이터를 갖고 있어,
+// 이를 적절하게 변환하기 위한 컨버터입니다.
+// 사이트 시스템 마이그레이션이 완료된 뒤에는 제거해야 합니다.
+export class LegacyDateConverter extends Type<Date | null, string> {
+  convertToDatabaseValue(value: Date | null): string {
+    if (value === null) {
+      return LEGACY_NON_STANDARD_DATE;
+    } else {
+      // 밀리초 제거 후 `T`를 공백으로 대체하여 반환합니다.
+      // ex) `2025-02-10T17:11:56.977Z` -> `2025-02-10 17:11:56`
+      return value.toISOString().slice(0, 19).replace('T', ' ');
+    }
+  }
+
+  convertToJSValue(value: string): Date | null {
+    if (value === LEGACY_NON_STANDARD_DATE) {
+      return null;
+    } else {
+      return new Date(value);
+    }
+  }
+}


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

non-standard인 레거시 날짜 데이터(`0000-00-00 00:00:00`)를 처리할 수 있도록 컨버터를 추가하고 적용합니다.
이후에는 해당하는 데이터를 `NULL`로 관리 할 예정입니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

기존 데이터를 갖고 운영 중인 PHP 로직이 있기 때문에, 데이터를 함부로 바꿀 수는 없습니다.
따라서, 관련 mysql 설정 및 mikro-orm 컬럼 설정을 수정하였습니다.