### PR TITLE
chore: tsconfigRootDir를 상대경로로 변경

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,7 +42,7 @@ export default [
 
       parserOptions: {
         project: 'tsconfig.json',
-        tsconfigRootDir: '/Users/lery/khlug/sight-backend',
+        tsconfigRootDir: './',
       },
     },
 


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->
`eslint.config.mjs` 내의 `tsconfigRootDir`를 `./`로 변경합니다.


### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->
기존 해당 속성이 maintainer분의 절대경로로 작성되어 있어, 다른 기여자의 PC에서 로드되지 않는 문제가 발생해 상대경로로 변경하였습니다. (Issue #108)