### PR TITLE
fix: 디스코드 봇 토큰이 존재하지 않으면 디스코드로 연결하지 않도록 수정

### DIFF
--- a/src/core/discord/DiscordClient.ts
+++ b/src/core/discord/DiscordClient.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { ConsoleLogger, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Client, GatewayIntentBits } from 'discord.js';
 
@@ -8,6 +8,7 @@ import { DiscordConfig } from '@khlug/core/config/DiscordConfig';
 export class DiscordClient {
   private readonly client: Client;
   private readonly token: string;
+  private readonly logger: ConsoleLogger;
 
   constructor(configService: ConfigService) {
     const config = configService.getOrThrow<DiscordConfig>('discord');
@@ -16,6 +17,7 @@ export class DiscordClient {
       intents: [GatewayIntentBits.GuildMembers],
     });
     this.token = config.botToken;
+    this.logger = new ConsoleLogger(DiscordClient.name);
   }
 
   on(...args: Parameters<Client['on']>) {
@@ -23,6 +25,13 @@ export class DiscordClient {
   }
 
   async login(): Promise<void> {
+    if (!this.token) {
+      this.logger.warn(
+        '디스코드 봇 토큰이 누락되어 디스코드 클라이언트의 로그인을 수행하지 않습니다.',
+      );
+      return;
+    }
+
     await this.client.login(this.token);
   }
 }


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

디스코드 봇 토큰이 존재하지 않으면 디스코드로 연결하지 않도록 수정합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

로컬 개발 시 디스코드 기능을 개발하지 않더라도 디스코드 봇 토큰이 존재하지 않으면 로그인이 실패하여 서버가 켜지지 않는 문제가 있습니다. 이를 해결하기 위해 토큰이 존재하지 않는 경우 `Client@login`을 수정하지 않도록 수정하였습니다.
