### PR TITLE
feat: 회원 탈퇴 기능 구현

### DIFF
--- a/src/app/AppModule.ts
+++ b/src/app/AppModule.ts
@@ -22,6 +22,7 @@ import { GetDoorLockPasswordQueryHandler } from '@khlug/app/application/infraBlu
 import { ApplyUserInfoToEnteredDiscordUserCommandHandler } from '@khlug/app/application/user/command/applyUserInfoToEnteredDiscordUser/ApplyUserInfoToEnteredDiscordUserCommandHandler';
 import { CreateDiscordIntegrationCommandHandler } from '@khlug/app/application/user/command/createDiscordIntegration/CreateDiscordIntegrationCommandHandler';
 import { CreateDiscordOAuth2UrlCommandHandler } from '@khlug/app/application/user/command/createDiscordOAuth2Url/CreateDiscordOAuth2UrlCommandHandler';
+import { DeleteUserCommandHandler } from '@khlug/app/application/user/command/deleteUser/DeleteUserCommandHandler';
 import { RemoveDiscordIntegrationCommandHandler } from '@khlug/app/application/user/command/removeDiscordIntegration/RemoveDiscordIntegrationCommandHandler';
 import { GetDiscordIntegrationQueryHandler } from '@khlug/app/application/user/query/getDiscordIntegration/GetDiscordIntegrationQueryHandler';
 import { DiscordIntegrationQueryToken } from '@khlug/app/application/user/query/IDiscordIntegrationQuery';
@@ -59,6 +60,7 @@ const commandHandlers: Provider[] = [
   CreateDiscordOAuth2UrlCommandHandler,
   RemoveDiscordIntegrationCommandHandler,
   ApplyUserInfoToEnteredDiscordUserCommandHandler,
+  DeleteUserCommandHandler,
 ];
 const queryHandlers: Provider[] = [
   GetDoorLockPasswordQueryHandler,

--- a/src/app/application/user/command/createDiscordIntegration/CreateDiscordIntegrationCommandHandler.spec.ts
+++ b/src/app/application/user/command/createDiscordIntegration/CreateDiscordIntegrationCommandHandler.spec.ts
@@ -53,7 +53,7 @@ describe('CreateDiscordIntegrationCommandHandler', () => {
           provide: DiscordIntegrationRepositoryToken,
           useValue: {
             findByUserId: jest.fn(),
-            insert: jest.fn(),
+            save: jest.fn(),
           },
         },
       ],
@@ -104,7 +104,7 @@ describe('CreateDiscordIntegrationCommandHandler', () => {
       });
       await handler.execute(command);
 
-      expect(discordIntegrationRepository.insert).not.toHaveBeenCalled();
+      expect(discordIntegrationRepository.save).not.toHaveBeenCalled();
     });
 
     test('새로운 디스코드 연동 정보를 생성해야 한다', async () => {
@@ -124,7 +124,7 @@ describe('CreateDiscordIntegrationCommandHandler', () => {
       });
       await handler.execute(command);
 
-      expect(discordIntegrationRepository.insert).toHaveBeenCalled();
+      expect(discordIntegrationRepository.save).toHaveBeenCalled();
     });
 
     test('유저 정보를 디스코드 유저에 반영해야 한다', async () => {

--- a/src/app/application/user/command/createDiscordIntegration/CreateDiscordIntegrationCommandHandler.ts
+++ b/src/app/application/user/command/createDiscordIntegration/CreateDiscordIntegrationCommandHandler.ts
@@ -60,7 +60,7 @@ export class CreateDiscordIntegrationCommandHandler
       discordUserId,
       createdAt: new Date(),
     });
-    await this.discordIntegrationRepository.insert(newDiscordIntegration);
+    await this.discordIntegrationRepository.save(newDiscordIntegration);
 
     await this.discordMemberService.reflectUserInfoToDiscordUser(userId);
   }

--- a/src/app/application/user/command/deleteUser/DeleteUserCommand.ts
+++ b/src/app/application/user/command/deleteUser/DeleteUserCommand.ts
@@ -1,0 +1,3 @@
+export class DeleteUserCommand {
+  constructor(readonly userId: number) {}
+}

--- a/src/app/application/user/command/deleteUser/DeleteUserCommandHandler.spec.ts
+++ b/src/app/application/user/command/deleteUser/DeleteUserCommandHandler.spec.ts
@@ -1,0 +1,69 @@
+import { EntityRepository } from '@mikro-orm/mysql';
+import { getRepositoryToken } from '@mikro-orm/nestjs';
+import { Test } from '@nestjs/testing';
+import { advanceTo, clear } from 'jest-date-mock';
+
+import { DeleteUserCommand } from '@khlug/app/application/user/command/deleteUser/DeleteUserCommand';
+import { DeleteUserCommandHandler } from '@khlug/app/application/user/command/deleteUser/DeleteUserCommandHandler';
+
+import { User } from '@khlug/app/domain/user/model/User';
+
+import { UserFixture } from '@khlug/__test__/fixtures/domain';
+import { Message } from '@khlug/constant/message';
+
+describe('DeleteUserCommandHandler', () => {
+  let handler: DeleteUserCommandHandler;
+  let userRepository: jest.Mocked<EntityRepository<User>>;
+
+  beforeEach(async () => {
+    advanceTo(new Date());
+
+    const em = {
+      persistAndFlush: jest.fn(),
+    };
+
+    const testModule = await Test.createTestingModule({
+      providers: [
+        DeleteUserCommandHandler,
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            findOne: jest.fn(),
+            getEntityManager: jest.fn().mockReturnValue(em),
+          },
+        },
+      ],
+    }).compile();
+
+    handler = testModule.get(DeleteUserCommandHandler);
+    userRepository = testModule.get(getRepositoryToken(User));
+  });
+
+  afterEach(() => clear());
+
+  describe('execute', () => {
+    test('유저가 존재하지 않으면 예외를 발생시켜야 한다', async () => {
+      const userId = 123;
+
+      userRepository.findOne.mockResolvedValue(null);
+
+      const command = new DeleteUserCommand(userId);
+      await expect(handler.execute(command)).rejects.toThrow(
+        Message.USER_NOT_FOUND,
+      );
+    });
+
+    test('유저를 제거해야 한다', async () => {
+      const user = UserFixture.undergraduated();
+
+      userRepository.findOne.mockResolvedValue(user);
+
+      const command = new DeleteUserCommand(user.id);
+      await handler.execute(command);
+
+      expect(
+        userRepository.getEntityManager().persistAndFlush,
+      ).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/application/user/command/deleteUser/DeleteUserCommandHandler.ts
+++ b/src/app/application/user/command/deleteUser/DeleteUserCommandHandler.ts
@@ -1,0 +1,36 @@
+import { EntityRepository } from '@mikro-orm/mysql';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+
+import { DeleteUserCommand } from '@khlug/app/application/user/command/deleteUser/DeleteUserCommand';
+
+import { User } from '@khlug/app/domain/user/model/User';
+
+import { Message } from '@khlug/constant/message';
+
+@CommandHandler(DeleteUserCommand)
+export class DeleteUserCommandHandler
+  implements ICommandHandler<DeleteUserCommand>
+{
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: EntityRepository<User>,
+  ) {}
+
+  async execute(command: DeleteUserCommand): Promise<void> {
+    const { userId } = command;
+
+    const user = await this.userRepository.findOne(userId);
+    if (!user) {
+      throw new NotFoundException(Message.USER_NOT_FOUND);
+    }
+
+    user.leave();
+
+    // TODO: UserRepository 구현하여 사용하도록 수정 필요
+    await this.userRepository.getEntityManager().persistAndFlush(user);
+
+    // TODO: 운영진에게 탈퇴 관련 메시지 전송 필요
+  }
+}

--- a/src/app/application/user/command/deleteUser/DeleteUserCommandHandler.ts
+++ b/src/app/application/user/command/deleteUser/DeleteUserCommandHandler.ts
@@ -4,6 +4,7 @@ import { NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 import { DeleteUserCommand } from '@khlug/app/application/user/command/deleteUser/DeleteUserCommand';
+import { DiscordMemberService } from '@khlug/app/application/user/service/DiscordMemberService';
 
 import { User } from '@khlug/app/domain/user/model/User';
 
@@ -16,6 +17,7 @@ export class DeleteUserCommandHandler
   constructor(
     @InjectRepository(User)
     private readonly userRepository: EntityRepository<User>,
+    private readonly discordMemberService: DiscordMemberService,
   ) {}
 
   async execute(command: DeleteUserCommand): Promise<void> {
@@ -32,5 +34,7 @@ export class DeleteUserCommandHandler
     await this.userRepository.getEntityManager().persistAndFlush(user);
 
     // TODO: 운영진에게 탈퇴 관련 메시지 전송 필요
+
+    await this.discordMemberService.clearDiscordIntegration(userId);
   }
 }

--- a/src/app/application/user/command/removeDiscordIntegration/RemoveDiscordIntegrationCommandHandler.spec.ts
+++ b/src/app/application/user/command/removeDiscordIntegration/RemoveDiscordIntegrationCommandHandler.spec.ts
@@ -3,6 +3,7 @@ import { advanceTo, clear } from 'jest-date-mock';
 
 import { RemoveDiscordIntegrationCommand } from '@khlug/app/application/user/command/removeDiscordIntegration/RemoveDiscordIntegrationCommand';
 import { RemoveDiscordIntegrationCommandHandler } from '@khlug/app/application/user/command/removeDiscordIntegration/RemoveDiscordIntegrationCommandHandler';
+import { DiscordMemberService } from '@khlug/app/application/user/service/DiscordMemberService';
 
 import {
   DiscordIntegrationRepositoryToken,
@@ -15,6 +16,7 @@ import { Message } from '@khlug/constant/message';
 describe('RemoveDiscordIntegrationCommandHandler', () => {
   let handler: RemoveDiscordIntegrationCommandHandler;
   let discordIntegrationRepository: jest.Mocked<IDiscordIntegrationRepository>;
+  let discordMemberService: jest.Mocked<DiscordMemberService>;
 
   beforeEach(async () => {
     advanceTo(new Date());
@@ -26,7 +28,12 @@ describe('RemoveDiscordIntegrationCommandHandler', () => {
           provide: DiscordIntegrationRepositoryToken,
           useValue: {
             findByUserId: jest.fn(),
-            remove: jest.fn(),
+          },
+        },
+        {
+          provide: DiscordMemberService,
+          useValue: {
+            clearDiscordIntegration: jest.fn(),
           },
         },
       ],
@@ -36,6 +43,7 @@ describe('RemoveDiscordIntegrationCommandHandler', () => {
     discordIntegrationRepository = testModule.get(
       DiscordIntegrationRepositoryToken,
     );
+    discordMemberService = testModule.get(DiscordMemberService);
   });
 
   afterEach(() => clear());
@@ -61,7 +69,7 @@ describe('RemoveDiscordIntegrationCommandHandler', () => {
       const command = new RemoveDiscordIntegrationCommand(userId);
       await handler.execute(command);
 
-      expect(discordIntegrationRepository.remove).toHaveBeenCalled();
+      expect(discordMemberService.clearDiscordIntegration).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/application/user/command/removeDiscordIntegration/RemoveDiscordIntegrationCommandHandler.ts
+++ b/src/app/application/user/command/removeDiscordIntegration/RemoveDiscordIntegrationCommandHandler.ts
@@ -2,6 +2,7 @@ import { Inject, NotFoundException } from '@nestjs/common';
 import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
 
 import { RemoveDiscordIntegrationCommand } from '@khlug/app/application/user/command/removeDiscordIntegration/RemoveDiscordIntegrationCommand';
+import { DiscordMemberService } from '@khlug/app/application/user/service/DiscordMemberService';
 
 import {
   DiscordIntegrationRepositoryToken,
@@ -17,6 +18,7 @@ export class RemoveDiscordIntegrationCommandHandler
   constructor(
     @Inject(DiscordIntegrationRepositoryToken)
     private readonly discordIntegrationRepository: IDiscordIntegrationRepository,
+    private readonly discordMemberService: DiscordMemberService,
   ) {}
 
   async execute(command: RemoveDiscordIntegrationCommand): Promise<void> {
@@ -28,6 +30,6 @@ export class RemoveDiscordIntegrationCommandHandler
       throw new NotFoundException(Message.DISCORD_INTEGRATION_NOT_FOUND);
     }
 
-    await this.discordIntegrationRepository.remove(discordIntegration);
+    await this.discordMemberService.clearDiscordIntegration(userId);
   }
 }

--- a/src/app/application/user/service/DiscordMemberService.spec.ts
+++ b/src/app/application/user/service/DiscordMemberService.spec.ts
@@ -47,9 +47,7 @@ describe('DiscordMemberService', () => {
         {
           provide: getRepositoryToken(User),
           useValue: {
-            createQueryBuilder: jest.fn().mockReturnThis(),
-            where: jest.fn().mockReturnThis(),
-            getSingleResult: jest.fn(),
+            findOne: jest.fn(),
           },
         },
       ],
@@ -67,9 +65,7 @@ describe('DiscordMemberService', () => {
 
   describe('reflectUserInfoToDiscordUser', () => {
     test('유저가 존재하지 않으면 디스코드 멤버 정보를 수정하지 않아야 한다', async () => {
-      userRepository.createQueryBuilder().getSingleResult = jest
-        .fn()
-        .mockResolvedValueOnce(undefined);
+      userRepository.findOne.mockResolvedValue(null);
 
       await discordMemberService.reflectUserInfoToDiscordUser(1);
 
@@ -77,9 +73,7 @@ describe('DiscordMemberService', () => {
     });
 
     test('디스코드 연동 정보가 존재하지 않으면 디스코드 멤버 정보를 수정하지 않아야 한다', async () => {
-      userRepository.createQueryBuilder().getSingleResult = jest
-        .fn()
-        .mockResolvedValueOnce(UserFixture.undergraduated());
+      userRepository.findOne.mockResolvedValue(UserFixture.undergraduated());
       discordIntegrationRepository.findByUserId = jest
         .fn()
         .mockResolvedValueOnce(undefined);
@@ -90,9 +84,7 @@ describe('DiscordMemberService', () => {
     });
 
     test('유저가 쿠러그 디스코드 채널에 들어와있지 않으면 디스코드 멤버 정보를 수정하지 않아야 한다', async () => {
-      userRepository.createQueryBuilder().getSingleResult = jest
-        .fn()
-        .mockResolvedValueOnce(UserFixture.undergraduated());
+      userRepository.findOne.mockResolvedValue(UserFixture.undergraduated());
       discordIntegrationRepository.findByUserId = jest
         .fn()
         .mockResolvedValueOnce(DiscordIntegrationFixture.normal());
@@ -106,9 +98,7 @@ describe('DiscordMemberService', () => {
     test('디스코드 멤버의 이름으로 유저의 이름을 사용해야 한다', async () => {
       const user = UserFixture.undergraduated();
 
-      userRepository.createQueryBuilder().getSingleResult = jest
-        .fn()
-        .mockResolvedValueOnce(user);
+      userRepository.findOne.mockResolvedValue(user);
       discordIntegrationRepository.findByUserId = jest
         .fn()
         .mockResolvedValueOnce(DiscordIntegrationFixture.normal());
@@ -124,9 +114,7 @@ describe('DiscordMemberService', () => {
     });
 
     test('유저가 활성 상태가 아니라면 디스코드 역할이 비어야 한다', async () => {
-      userRepository.createQueryBuilder().getSingleResult = jest
-        .fn()
-        .mockResolvedValueOnce(UserFixture.unauthorized());
+      userRepository.findOne.mockResolvedValue(UserFixture.unauthorized());
       discordIntegrationRepository.findByUserId = jest
         .fn()
         .mockResolvedValueOnce(DiscordIntegrationFixture.normal());
@@ -142,9 +130,7 @@ describe('DiscordMemberService', () => {
     });
 
     test('유저가 활성 상태이며 졸업 상태가 아니라면 "회원" 디스코드 역할을 가져야 한다', async () => {
-      userRepository.createQueryBuilder().getSingleResult = jest
-        .fn()
-        .mockResolvedValueOnce(UserFixture.undergraduated());
+      userRepository.findOne.mockResolvedValue(UserFixture.undergraduated());
       discordIntegrationRepository.findByUserId = jest
         .fn()
         .mockResolvedValueOnce(DiscordIntegrationFixture.normal());
@@ -160,9 +146,7 @@ describe('DiscordMemberService', () => {
     });
 
     test('유저가 활성 상태이며 졸업했다면 "명예 회원" 디스코드 역할을 가져야 한다', async () => {
-      userRepository.createQueryBuilder().getSingleResult = jest
-        .fn()
-        .mockResolvedValueOnce(UserFixture.graduated());
+      userRepository.findOne.mockResolvedValue(UserFixture.graduated());
       discordIntegrationRepository.findByUserId = jest
         .fn()
         .mockResolvedValueOnce(DiscordIntegrationFixture.normal());
@@ -178,9 +162,7 @@ describe('DiscordMemberService', () => {
     });
 
     test('유저가 운영진이라면 "운영진" 디스코드 역할을 가져야 한다', async () => {
-      userRepository.createQueryBuilder().getSingleResult = jest
-        .fn()
-        .mockResolvedValueOnce(UserFixture.manager());
+      userRepository.findOne.mockResolvedValueOnce(UserFixture.manager());
       discordIntegrationRepository.findByUserId = jest
         .fn()
         .mockResolvedValueOnce(DiscordIntegrationFixture.normal());

--- a/src/app/domain/discord/IDiscordIntegrationRepository.ts
+++ b/src/app/domain/discord/IDiscordIntegrationRepository.ts
@@ -9,6 +9,6 @@ export interface IDiscordIntegrationRepository {
   findByDiscordUserId: (
     discordUserId: string,
   ) => Promise<DiscordIntegration | null>;
-  insert: (discordIntegration: DiscordIntegration) => Promise<void>;
+  save: (discordIntegration: DiscordIntegration) => Promise<void>;
   remove: (discordIntegration: DiscordIntegration) => Promise<void>;
 }

--- a/src/app/domain/user/model/User.ts
+++ b/src/app/domain/user/model/User.ts
@@ -320,6 +320,26 @@ export class User extends AggregateRoot {
     return joinedAfterMidterm && joinedInThisSemester;
   }
 
+  leave(): void {
+    this._password = '';
+    this._profile = new Profile({
+      ...this._profile,
+      email: '',
+      number: 0,
+      phone: '',
+      homepage: '',
+      language: '',
+      prefer: '',
+    });
+    this._point = 0;
+    this._status = UserStatus.UNAUTHORIZED;
+    this._manager = false;
+    this._slack = null;
+    this._returnAt = null;
+    this._returnReason = null;
+    this._updatedAt = new Date();
+  }
+
   get id(): number {
     return this._id;
   }

--- a/src/app/infra/discord/DiscordApiAdapter.ts
+++ b/src/app/infra/discord/DiscordApiAdapter.ts
@@ -70,11 +70,9 @@ export class DiscordApiAdapter implements IDiscordApiAdapter {
       body['nick'] = nickname;
     }
 
-    if (roles && roles.length > 0) {
+    if (roles) {
       body['roles'] = roles.map((role) => this.roleMap[role]);
     }
-
-    console.log(body);
 
     if (Object.keys(body).length === 0) {
       return;
@@ -85,7 +83,6 @@ export class DiscordApiAdapter implements IDiscordApiAdapter {
         `/guilds/${this.guildId}/members/${discordUserId}`,
         body,
       );
-      this.logger.log(`Successfully modified member ${discordUserId}`);
     } catch (e) {
       const error = e as Error;
       this.logger.error(

--- a/src/app/infra/persistence/repository/mapper/DiscordIntegrationMapper.ts
+++ b/src/app/infra/persistence/repository/mapper/DiscordIntegrationMapper.ts
@@ -20,11 +20,13 @@ export class DiscordIntegrationMapper
   }
 
   toEntity(domain: DiscordIntegration): DiscordIntegrationEntity {
-    return {
-      id: domain.id,
-      userId: domain.userId,
-      discordUserId: domain.discordUserId,
-      createdAt: domain.createdAt,
-    };
+    const entity = new DiscordIntegrationEntity();
+
+    entity.id = domain.id;
+    entity.userId = domain.userId;
+    entity.discordUserId = domain.discordUserId;
+    entity.createdAt = domain.createdAt;
+
+    return entity;
   }
 }

--- a/src/constant/message.ts
+++ b/src/constant/message.ts
@@ -11,7 +11,7 @@ export const Message = {
   INVALID_DISCORD_STATE: '알 수 없는 디스코드 OAuth2 상태값입니다',
 
   // 404 Not Found
-  USER_NOT_FOUND: 'User not found',
+  USER_NOT_FOUND: '존재하지 않는 유저입니다',
   SOME_INTERESTS_NOT_FOUND: 'Some interests not found',
   GROUP_NOT_FOUND: 'Group not found',
   SOME_DOOR_LOCK_PASSWORD_NOT_FOUND: '일부 도어락 비밀번호가 존재하지 않습니다',


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

회원 탈퇴 기능을 구현합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

회원 탈퇴 시 디스코드 연동 정보를 제거해야 하는 상황인데, 회원 탈퇴 기능이 현재 레거시 서버에 구현되어 있으므로 이를 옮깁니다.