### PR TITLE
feat: 회원 졸업 처리 기능 구현

### DIFF
--- a/src/app/AppModule.ts
+++ b/src/app/AppModule.ts
@@ -23,6 +23,7 @@ import { ApplyUserInfoToEnteredDiscordUserCommandHandler } from '@khlug/app/appl
 import { CreateDiscordIntegrationCommandHandler } from '@khlug/app/application/user/command/createDiscordIntegration/CreateDiscordIntegrationCommandHandler';
 import { CreateDiscordOAuth2UrlCommandHandler } from '@khlug/app/application/user/command/createDiscordOAuth2Url/CreateDiscordOAuth2UrlCommandHandler';
 import { DeleteUserCommandHandler } from '@khlug/app/application/user/command/deleteUser/DeleteUserCommandHandler';
+import { GraduateUserCommandHandler } from '@khlug/app/application/user/command/graduateUser/GraduateUserCommandHandler';
 import { RemoveDiscordIntegrationCommandHandler } from '@khlug/app/application/user/command/removeDiscordIntegration/RemoveDiscordIntegrationCommandHandler';
 import { GetDiscordIntegrationQueryHandler } from '@khlug/app/application/user/query/getDiscordIntegration/GetDiscordIntegrationQueryHandler';
 import { DiscordIntegrationQueryToken } from '@khlug/app/application/user/query/IDiscordIntegrationQuery';
@@ -61,6 +62,7 @@ const commandHandlers: Provider[] = [
   RemoveDiscordIntegrationCommandHandler,
   ApplyUserInfoToEnteredDiscordUserCommandHandler,
   DeleteUserCommandHandler,
+  GraduateUserCommandHandler,
 ];
 const queryHandlers: Provider[] = [
   GetDoorLockPasswordQueryHandler,

--- a/src/app/application/user/command/graduateUser/GraduateUserCommand.ts
+++ b/src/app/application/user/command/graduateUser/GraduateUserCommand.ts
@@ -1,0 +1,3 @@
+export class GraduateUserCommand {
+  constructor(readonly userId: number) {}
+}

--- a/src/app/application/user/command/graduateUser/GraduateUserCommandHandler.spec.ts
+++ b/src/app/application/user/command/graduateUser/GraduateUserCommandHandler.spec.ts
@@ -62,11 +62,12 @@ describe('GraduateUserCommandHandler', () => {
       const user = UserFixture.undergraduated();
 
       userRepository.findOne.mockResolvedValue(user);
+      jest.spyOn(user, 'graduate');
 
       const command = new GraduateUserCommand(user.id);
       await handler.execute(command);
 
-      expect(user.graduate()).toBeUndefined();
+      expect(user.graduate).toHaveBeenCalled();
     });
 
     test('변경된 유저 정보를 디스코드에 반영해야 한다', async () => {

--- a/src/app/application/user/command/graduateUser/GraduateUserCommandHandler.spec.ts
+++ b/src/app/application/user/command/graduateUser/GraduateUserCommandHandler.spec.ts
@@ -1,0 +1,85 @@
+import { EntityRepository } from '@mikro-orm/mysql';
+import { getRepositoryToken } from '@mikro-orm/nestjs';
+import { Test } from '@nestjs/testing';
+import { advanceTo, clear } from 'jest-date-mock';
+
+import { GraduateUserCommand } from '@khlug/app/application/user/command/graduateUser/GraduateUserCommand';
+import { GraduateUserCommandHandler } from '@khlug/app/application/user/command/graduateUser/GraduateUserCommandHandler';
+import { DiscordMemberService } from '@khlug/app/application/user/service/DiscordMemberService';
+
+import { User } from '@khlug/app/domain/user/model/User';
+
+import { UserFixture } from '@khlug/__test__/fixtures/domain';
+import { Message } from '@khlug/constant/message';
+
+describe('GraduateUserCommandHandler', () => {
+  let handler: GraduateUserCommandHandler;
+  let userRepository: jest.Mocked<EntityRepository<User>>;
+  let discordMemberService: jest.Mocked<DiscordMemberService>;
+
+  beforeEach(async () => {
+    advanceTo(new Date());
+
+    const em = { persistAndFlush: jest.fn() };
+
+    const testModule = await Test.createTestingModule({
+      providers: [
+        GraduateUserCommandHandler,
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            findOne: jest.fn(),
+            getEntityManager: jest.fn().mockReturnValue(em),
+          },
+        },
+        {
+          provide: DiscordMemberService,
+          useValue: {
+            reflectUserInfoToDiscordUser: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    handler = testModule.get(GraduateUserCommandHandler);
+    userRepository = testModule.get(getRepositoryToken(User));
+    discordMemberService = testModule.get(DiscordMemberService);
+  });
+
+  afterEach(() => clear());
+
+  describe('execute', () => {
+    test('유저가 존재하지 않으면 예외가 발생해야 한다', async () => {
+      userRepository.findOne.mockResolvedValue(null);
+
+      const command = new GraduateUserCommand(1234);
+      await expect(handler.execute(command)).rejects.toThrow(
+        Message.USER_NOT_FOUND,
+      );
+    });
+
+    test('졸업 처리를 진행해야 한다', async () => {
+      const user = UserFixture.undergraduated();
+
+      userRepository.findOne.mockResolvedValue(user);
+
+      const command = new GraduateUserCommand(user.id);
+      await handler.execute(command);
+
+      expect(user.graduate()).toBeUndefined();
+    });
+
+    test('변경된 유저 정보를 디스코드에 반영해야 한다', async () => {
+      const user = UserFixture.undergraduated();
+
+      userRepository.findOne.mockResolvedValue(user);
+
+      const command = new GraduateUserCommand(user.id);
+      await handler.execute(command);
+
+      expect(
+        discordMemberService.reflectUserInfoToDiscordUser,
+      ).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/application/user/command/graduateUser/GraduateUserCommandHandler.ts
+++ b/src/app/application/user/command/graduateUser/GraduateUserCommandHandler.ts
@@ -1,0 +1,40 @@
+import { EntityRepository } from '@mikro-orm/core';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+
+import { GraduateUserCommand } from '@khlug/app/application/user/command/graduateUser/GraduateUserCommand';
+import { DiscordMemberService } from '@khlug/app/application/user/service/DiscordMemberService';
+
+import { User } from '@khlug/app/domain/user/model/User';
+
+import { Message } from '@khlug/constant/message';
+
+@CommandHandler(GraduateUserCommand)
+export class GraduateUserCommandHandler
+  implements ICommandHandler<GraduateUserCommand>
+{
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: EntityRepository<User>,
+    private readonly discordMemberService: DiscordMemberService,
+  ) {}
+
+  async execute(command: GraduateUserCommand): Promise<void> {
+    const { userId } = command;
+
+    const user = await this.userRepository.findOne(userId);
+    if (!user) {
+      throw new NotFoundException(Message.USER_NOT_FOUND);
+    }
+
+    user.graduate();
+
+    // TODO: UserRepository 구현하여 사용하도록 수정 필요
+    await this.userRepository.getEntityManager().persistAndFlush(user);
+
+    // TODO: 운영진 및 졸업자에게 관련 메시지 전송 필요
+
+    await this.discordMemberService.reflectUserInfoToDiscordUser(userId);
+  }
+}

--- a/src/app/domain/user/model/User.spec.ts
+++ b/src/app/domain/user/model/User.spec.ts
@@ -509,4 +509,41 @@ describe('User', () => {
       expect(user.needPayHalfFee()).toEqual(false);
     });
   });
+
+  describe('graduate', () => {
+    test('이미 졸업한 회원이라면 예외를 발생시켜야 한다', () => {
+      const user = UserFixture.graduated();
+
+      expect(() => user.graduate()).toThrowError(
+        Message.USER_ALREADY_GRADUATED,
+      );
+    });
+
+    test('회원을 졸업 처리해야 한다', () => {
+      const user = UserFixture.undergraduated();
+
+      user.graduate();
+
+      expect(user.studentStatus).toEqual(StudentStatus.GRADUATE);
+      expect(user.profile.grade).toEqual(0);
+      expect(user.manager).toEqual(false);
+      expect(user.updatedAt).toEqual(new Date());
+    });
+  });
+
+  describe('isGraduated', () => {
+    test('졸업한 회원이라면 `true`를 반환해야 한다', () => {
+      const user = UserFixture.raw({ studentStatus: StudentStatus.GRADUATE });
+
+      expect(user.isGraduated()).toEqual(true);
+    });
+
+    test('졸업하지 않은 회원이라면 `false`를 반환해야 한다', () => {
+      const user = UserFixture.raw({
+        studentStatus: StudentStatus.UNDERGRADUATE,
+      });
+
+      expect(user.isGraduated()).toEqual(false);
+    });
+  });
 });

--- a/src/app/domain/user/model/User.ts
+++ b/src/app/domain/user/model/User.ts
@@ -320,6 +320,20 @@ export class User extends AggregateRoot {
     return joinedAfterMidterm && joinedInThisSemester;
   }
 
+  graduate(): void {
+    if (this.isGraduated()) {
+      throw new UnprocessableEntityException(Message.USER_ALREADY_GRADUATED);
+    }
+
+    this._studentStatus = StudentStatus.GRADUATE;
+    this._profile = new Profile({
+      ...this._profile,
+      grade: 0,
+    });
+    this._manager = false;
+    this._updatedAt = new Date();
+  }
+
   leave(): void {
     this._password = '';
     this._profile = new Profile({
@@ -338,6 +352,10 @@ export class User extends AggregateRoot {
     this._returnAt = null;
     this._returnReason = null;
     this._updatedAt = new Date();
+  }
+
+  isGraduated(): boolean {
+    return this._studentStatus === StudentStatus.GRADUATE;
   }
 
   get id(): number {

--- a/src/app/interface/user/public/UserController.ts
+++ b/src/app/interface/user/public/UserController.ts
@@ -27,6 +27,7 @@ import { CreateDiscordIntegrationCommand } from '@khlug/app/application/user/com
 import { CreateDiscordOAuth2UrlCommand } from '@khlug/app/application/user/command/createDiscordOAuth2Url/CreateDiscordOAuth2UrlCommand';
 import { CreateDiscordOAuth2UrlCommandResult } from '@khlug/app/application/user/command/createDiscordOAuth2Url/CreateDiscordOauth2UrlCommandResult';
 import { DeleteUserCommand } from '@khlug/app/application/user/command/deleteUser/DeleteUserCommand';
+import { GraduateUserCommand } from '@khlug/app/application/user/command/graduateUser/GraduateUserCommand';
 import { RemoveDiscordIntegrationCommand } from '@khlug/app/application/user/command/removeDiscordIntegration/RemoveDiscordIntegrationCommand';
 import { GetDiscordIntegrationQuery } from '@khlug/app/application/user/query/getDiscordIntegration/GetDiscordIntegrationQuery';
 import { GetDiscordIntegrationQueryResult } from '@khlug/app/application/user/query/getDiscordIntegration/GetDiscordIntegrationQueryResult';
@@ -37,6 +38,23 @@ export class UserController {
     private readonly queryBus: QueryBus,
     private readonly commandBus: CommandBus,
   ) {}
+
+  @Post('/users/@me/graduate')
+  @Redirect()
+  @Auth([UserRole.USER, UserRole.MANAGER])
+  @ApiOperation({ summary: '졸업 신고' })
+  async graduateCurrentUser(
+    @Requester() requester: IRequester,
+  ): Promise<HttpRedirectResponse> {
+    const command = new GraduateUserCommand(requester.userId);
+    await this.commandBus.execute(command);
+
+    // TODO: 추후 클라이언트에서 처리하도록 수정
+    return {
+      statusCode: HttpStatus.FOUND,
+      url: 'https://khlug.org/my',
+    };
+  }
 
   @Delete('/users/@me')
   @Auth([UserRole.USER, UserRole.MANAGER])

--- a/src/constant/message.ts
+++ b/src/constant/message.ts
@@ -27,4 +27,5 @@ export const Message = {
   DEFAULT_BOOKMARKED_GROUP: 'Cannot add bookmark default bookmarked group',
   DISCORD_INTEGRATION_FAILED: '디스코드 연동에 실패했습니다',
   DISCORD_API_FAILED: '디스코드 API 호출에 실패했습니다',
+  USER_ALREADY_GRADUATED: '이미 졸업 신고한 회원입니다',
 };


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

회원 졸업 처리를 구현합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

졸업 신고 시 디스코드 연동 정보를 갱신해야 하는 상황인데, 회원 탈퇴 기능이 현재 레거시 서버에 구현되어 있으므로 이를 옮깁니다.