### PR TITLE
feat: 큐가 적용된 비동기 알람 전송 클래스 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "dayjs": "^1.11.13",
         "discord.js": "^14.18.0",
         "nestjs-cls": "^4.5.0",
+        "p-queue": "^6.6.2",
         "php-serialize": "^5.0.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
@@ -5151,6 +5152,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "dev": true,
@@ -8051,6 +8057,14 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "dev": true,
@@ -8077,6 +8091,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -13874,6 +13914,11 @@
     "etag": {
       "version": "1.8.1"
     },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "events": {
       "version": "3.3.0",
       "dev": true
@@ -15747,6 +15792,11 @@
       "version": "3.0.0",
       "dev": true
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
+    },
     "p-limit": {
       "version": "3.1.0",
       "dev": true,
@@ -15759,6 +15809,23 @@
       "dev": true,
       "requires": {
         "p-limit": "^3.0.2"
+      }
+    },
+    "p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dayjs": "^1.11.13",
     "discord.js": "^14.18.0",
     "nestjs-cls": "^4.5.0",
+    "p-queue": "^6.6.2",
     "php-serialize": "^5.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/src/app/domain/adapter/INotifier.ts
+++ b/src/app/domain/adapter/INotifier.ts
@@ -7,20 +7,16 @@ export type NotifierSendParams = {
   category: NotificationCategory;
 };
 
-export type NotifierSendToManagersParams = Omit<
-  NotifierSendParams,
-  'targetUserId'
->;
-
-export type NotifierBroadcastParams = Omit<
-  NotifierSendParams,
-  'sourceUserId' | 'targetUserId'
->;
+export type NotifierSendToChannelParams = {
+  sourceUserId?: number;
+  channelId: string;
+  message: string;
+  category: NotificationCategory;
+};
 
 export const NotifierToken = Symbol('Notifier');
 
 export interface INotifier {
   send: (params: NotifierSendParams) => void;
-  sendToManagers: (params: NotifierSendToManagersParams) => void;
-  broadcast: (params: NotifierBroadcastParams) => void;
+  sendToChannel: (params: NotifierSendToChannelParams) => void;
 }

--- a/src/app/infra/notification/QueuedBaseNotifier.spec.ts
+++ b/src/app/infra/notification/QueuedBaseNotifier.spec.ts
@@ -1,0 +1,94 @@
+import { advanceTo, clear } from 'jest-date-mock';
+
+const queue: any = {};
+jest.mock('p-queue', () => {
+  return jest.fn().mockImplementation(() => queue);
+});
+
+import { ConsoleLogger } from '@nestjs/common';
+
+import { QueuedBaseNotifier } from '@khlug/app/infra/notification/QueuedBaseNotifier';
+
+import { NotificationCategory } from '@khlug/constant/notification';
+
+class NoopNotifier extends QueuedBaseNotifier {
+  protected async sendImpl(): Promise<void> {}
+  protected async sendToChannelImpl(): Promise<void> {}
+}
+
+class ThrowErrorNotifier extends QueuedBaseNotifier {
+  protected async sendImpl(): Promise<void> {
+    throw new Error('Test error');
+  }
+  protected async sendToChannelImpl(): Promise<void> {
+    throw new Error('Test error');
+  }
+}
+
+describe('QueuedBaseNotifier', () => {
+  beforeEach(() => {
+    advanceTo(new Date());
+
+    queue.add = jest.fn((fn: () => Promise<void>) => fn()) as any;
+  });
+
+  afterEach(() => clear());
+
+  describe('send', () => {
+    test('큐에 알람 전송 작업을 추가해야 한다', () => {
+      const notifier = new NoopNotifier();
+
+      notifier.send({
+        sourceUserId: 1,
+        targetUserId: 2,
+        category: NotificationCategory.MY_ACTIVITY,
+        message: 'hello',
+      });
+
+      expect(queue.add).toHaveBeenCalledTimes(1);
+    });
+
+    test('전송 작업 처리 중 에러가 발생해도 정상적으로 종료되어야 한다', async () => {
+      const logger: jest.Mocked<ConsoleLogger> = { error: jest.fn() } as any;
+      const notifier = new ThrowErrorNotifier(logger);
+
+      expect(() =>
+        notifier.send({
+          sourceUserId: 1,
+          targetUserId: 2,
+          category: NotificationCategory.MY_ACTIVITY,
+          message: 'hello',
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('sendToChannel', () => {
+    test('큐에 알람 전송 작업을 추가해야 한다', () => {
+      const notifier = new NoopNotifier();
+
+      notifier.sendToChannel({
+        sourceUserId: 1,
+        channelId: '123',
+        category: NotificationCategory.MY_ACTIVITY,
+        message: 'hello',
+      });
+
+      expect(queue.add).toHaveBeenCalledTimes(1);
+    });
+
+    test('전송 작업 처리 중 에러가 발생해도 정상적으로 종료되어야 한다', async () => {
+      const logger: jest.Mocked<ConsoleLogger> = { error: jest.fn() } as any;
+      const notifier = new ThrowErrorNotifier(logger);
+
+      expect(() =>
+        notifier.sendToChannel({
+          sourceUserId: 1,
+          channelId: '123',
+          category: NotificationCategory.MY_ACTIVITY,
+          message: 'hello',
+        }),
+      ).not.toThrow();
+    });
+  });
+});

--- a/src/app/infra/notification/QueuedBaseNotifier.ts
+++ b/src/app/infra/notification/QueuedBaseNotifier.ts
@@ -1,0 +1,58 @@
+import { ConsoleLogger } from '@nestjs/common';
+import PQueue from 'p-queue';
+
+import {
+  INotifier,
+  NotifierSendParams,
+  NotifierSendToChannelParams,
+} from '@khlug/app/domain/adapter/INotifier';
+
+const THROTTLE_COUNT = 20;
+
+export abstract class QueuedBaseNotifier implements INotifier {
+  // TODO: Graceful shutdown 시 큐에 남아있는 알람을 처리할 수 있도록 구현해야 함
+  //       이후 디스코드 - 유저 간 관계는 별도 모듈로 분리 후 추상화된 서비스로 접근할 수 있도록 수정할 예정
+  private queue: PQueue;
+
+  constructor(private logger = new ConsoleLogger(this.constructor.name)) {
+    this.queue = new PQueue({
+      interval: 1000,
+      intervalCap: THROTTLE_COUNT,
+      concurrency: THROTTLE_COUNT,
+    });
+  }
+
+  send(params: NotifierSendParams): void {
+    this.queue.add(() => {
+      this.wrapPromise(this.sendImpl(params));
+    });
+  }
+
+  sendToChannel(params: NotifierSendToChannelParams): void {
+    this.queue.add(() => {
+      this.wrapPromise(this.sendToChannelImpl(params));
+    });
+  }
+
+  // 알람 전송을 완전히 비동기 상황인 큐 내에서 처리하기 때문에 에러 발생 시 서버가 완전히 죽습니다.
+  // 이를 방지하기 위해 `catch`를 사용하여 핸들링할 수 있또록 하고, 에러 발생 시 로그를 남기게 합니다.
+  private wrapPromise(sendFnPromise: Promise<void>) {
+    sendFnPromise.catch((err) => {
+      if (err instanceof Error) {
+        this.logger.error(
+          `Error occurred while send notification: ${err.message}`,
+          err.stack,
+        );
+      } else {
+        this.logger.error(
+          `Unknown error occurred while send notification: ${err}`,
+        );
+      }
+    });
+  }
+
+  protected abstract sendImpl(params: NotifierSendParams): Promise<void>;
+  protected abstract sendToChannelImpl(
+    params: NotifierSendToChannelParams,
+  ): Promise<void>;
+}


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

큐가 적용된 비동기 알람 전송 클래스를 구현합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

디스코드는 50req/s의 rate limit을 API 별로 가지고 있습니다. 따라서 제일 호출이 많은 API인 메시지 전송은 제한보다 더 낮은 20req/s로 제한을 겁니다.

사실 왠만해서는 넘을 일이 없긴 한데 메시지 전송 처리 자체를 비동기로 빼서, 로직이 처리되는 데에 영향이 가지 않도록 하는 것 또한 목적입니다.