### PR TITLE
feat: 캐싱이 적용된 디스코드 유저 아이디 매퍼 구현

### DIFF
--- a/src/app/AppModule.ts
+++ b/src/app/AppModule.ts
@@ -4,6 +4,8 @@ import { Module, Provider } from '@nestjs/common';
 import { DiscordApiAdapter } from '@khlug/app/infra/discord/DiscordApiAdapter';
 import { DiscordOAuth2Adapter } from '@khlug/app/infra/discord/DiscordOAuth2Adapter';
 import { DiscordStateGenerator } from '@khlug/app/infra/discord/DiscordStateGenerator';
+import { CachedDiscordUserIdMapper } from '@khlug/app/infra/notification/CachedDiscordUserIdMapper';
+import { DiscordUserIdMapperToken } from '@khlug/app/infra/notification/IDiscordUserIdMapper';
 import { DiscordIntegrationEntity } from '@khlug/app/infra/persistence/entity/DiscordIntegrationEntity';
 import { DiscordIntegrationQuery } from '@khlug/app/infra/persistence/query/DiscordIntegrationQuery';
 import { DiscordIntegrationRepository } from '@khlug/app/infra/persistence/repository/DiscordIntegrationRepository';
@@ -49,7 +51,15 @@ const repositories: Provider[] = [
     useClass: DiscordIntegrationRepository,
   },
 ];
-const mappers: Provider[] = [DiscordIntegrationMapper];
+const entityMappers: Provider[] = [DiscordIntegrationMapper];
+
+// 도메인과 무관한 실제 구현체를 넣습니다.
+const implementations: Provider[] = [
+  {
+    provide: DiscordUserIdMapperToken,
+    useValue: CachedDiscordUserIdMapper,
+  },
+];
 
 const controllers = [UserController];
 const manageControllers = [InfraBlueManageController, UserManageController];
@@ -85,7 +95,8 @@ const services: Provider[] = [DiscordMemberService];
     ...adapters,
     ...queries,
     ...repositories,
-    ...mappers,
+    ...entityMappers,
+    ...implementations,
     ...discordEventHandlers,
     ...commandHandlers,
     ...queryHandlers,

--- a/src/app/infra/notification/CachedDiscordUserIdMapper.spec.ts
+++ b/src/app/infra/notification/CachedDiscordUserIdMapper.spec.ts
@@ -1,0 +1,87 @@
+import { Test } from '@nestjs/testing';
+import { advanceTo, clear } from 'jest-date-mock';
+
+import { CachedDiscordUserIdMapper } from '@khlug/app/infra/notification/CachedDiscordUserIdMapper';
+
+import {
+  DiscordIntegrationRepositoryToken,
+  IDiscordIntegrationRepository,
+} from '@khlug/app/domain/discord/IDiscordIntegrationRepository';
+
+import { DiscordIntegrationFixture } from '@khlug/__test__/fixtures/DiscordIntegrationFixture';
+
+describe('CachedDiscordUserIdMapper', () => {
+  let mapper: CachedDiscordUserIdMapper;
+  let discordIntegrationRepository: jest.Mocked<IDiscordIntegrationRepository>;
+
+  beforeEach(async () => {
+    advanceTo(new Date());
+
+    const testModule = await Test.createTestingModule({
+      providers: [
+        CachedDiscordUserIdMapper,
+        {
+          provide: DiscordIntegrationRepositoryToken,
+          useValue: { findByUserId: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    mapper = testModule.get(CachedDiscordUserIdMapper);
+    discordIntegrationRepository = testModule.get(
+      DiscordIntegrationRepositoryToken,
+    );
+  });
+
+  afterEach(() => clear());
+
+  describe('toDiscordUserId', () => {
+    test('처음 호출했다면 레포지토리에서 조회해야 한다', async () => {
+      const discordIntegration = DiscordIntegrationFixture.normal();
+      const dbFindFn = discordIntegrationRepository.findByUserId;
+
+      dbFindFn.mockResolvedValue(discordIntegration);
+
+      await mapper.toDiscordUserId(discordIntegration.userId);
+
+      expect(dbFindFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('1시간 이내에 다시 호출했다면 레포지토리를 거치지 않아야 한다', async () => {
+      const discordIntegration = DiscordIntegrationFixture.normal();
+      const dbFindFn = discordIntegrationRepository.findByUserId;
+
+      dbFindFn.mockResolvedValue(discordIntegration);
+
+      await mapper.toDiscordUserId(discordIntegration.userId);
+      await mapper.toDiscordUserId(discordIntegration.userId);
+
+      expect(dbFindFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('1시간이 지난 시점에 다시 호출했다면 레포지토리에서 가져와야 한다', async () => {
+      const discordIntegration = DiscordIntegrationFixture.normal();
+      const dbFindFn = discordIntegrationRepository.findByUserId;
+
+      dbFindFn.mockResolvedValue(discordIntegration);
+
+      await mapper.toDiscordUserId(discordIntegration.userId);
+
+      advanceTo(Date.now() + 1000 * 60 * 60 + 1);
+      await mapper.toDiscordUserId(discordIntegration.userId);
+
+      expect(dbFindFn).toHaveBeenCalledTimes(2);
+    });
+
+    test('디스코드 연동이 되어 있지 않다면 캐싱하지 않아야 한다', async () => {
+      const dbFindFn = discordIntegrationRepository.findByUserId;
+
+      dbFindFn.mockResolvedValue(null);
+
+      await mapper.toDiscordUserId(123);
+      await mapper.toDiscordUserId(123);
+
+      expect(dbFindFn).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/app/infra/notification/CachedDiscordUserIdMapper.ts
+++ b/src/app/infra/notification/CachedDiscordUserIdMapper.ts
@@ -1,0 +1,73 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { IDiscordUserIdMapper } from '@khlug/app/infra/notification/IDiscordUserIdMapper';
+
+import {
+  DiscordIntegrationRepositoryToken,
+  IDiscordIntegrationRepository,
+} from '@khlug/app/domain/discord/IDiscordIntegrationRepository';
+
+type CachedDiscordUserId = {
+  discordUserId: string;
+  expiredAt: Date;
+};
+
+const CACHE_EXPIRATION_MS = 1000 * 60 * 60; // 1 hour
+
+@Injectable()
+export class CachedDiscordUserIdMapper implements IDiscordUserIdMapper {
+  private readonly cache = new Map<number, CachedDiscordUserId>();
+
+  constructor(
+    @Inject(DiscordIntegrationRepositoryToken)
+    private readonly discordIntegrationRepository: IDiscordIntegrationRepository,
+  ) {}
+
+  async toDiscordUserId(userId: number): Promise<string | null> {
+    const cachedDiscordUserId = this.getOrRemoveCacheIfStale(userId);
+
+    if (cachedDiscordUserId) {
+      return cachedDiscordUserId;
+    }
+
+    const discordUserId = await this.getDiscordUserIdFromRepository(userId);
+
+    if (!discordUserId) {
+      return null;
+    }
+
+    return discordUserId;
+  }
+
+  private getOrRemoveCacheIfStale(userId: number): string | null {
+    const cache = this.cache.get(userId);
+
+    if (cache && cache.expiredAt < new Date()) {
+      this.cache.delete(userId);
+      return null;
+    }
+
+    return cache?.discordUserId ?? null;
+  }
+
+  private async getDiscordUserIdFromRepository(
+    userId: number,
+  ): Promise<string | null> {
+    const discordIntegration =
+      await this.discordIntegrationRepository.findByUserId(userId);
+
+    if (!discordIntegration) {
+      return null;
+    }
+
+    const discordUserId = discordIntegration.discordUserId;
+    this.saveToCache(userId, discordUserId);
+
+    return discordUserId;
+  }
+
+  private saveToCache(userId: number, discordUserId: string): void {
+    const expiredAt = new Date(Date.now() + CACHE_EXPIRATION_MS);
+    this.cache.set(userId, { discordUserId, expiredAt });
+  }
+}

--- a/src/app/infra/notification/CachedDiscordUserIdMapper.ts
+++ b/src/app/infra/notification/CachedDiscordUserIdMapper.ts
@@ -14,6 +14,7 @@ type CachedDiscordUserId = {
 
 const CACHE_EXPIRATION_MS = 1000 * 60 * 60; // 1 hour
 
+// TODO: 추후 디스코드 모듈로 분리 시 유저가 연동을 해제할 때 제거하도록 구현해야 함
 @Injectable()
 export class CachedDiscordUserIdMapper implements IDiscordUserIdMapper {
   private readonly cache = new Map<number, CachedDiscordUserId>();

--- a/src/app/infra/notification/IDiscordUserIdMapper.ts
+++ b/src/app/infra/notification/IDiscordUserIdMapper.ts
@@ -1,0 +1,5 @@
+export const DiscordUserIdMapperToken = Symbol('DiscordUserIdMapper');
+
+export interface IDiscordUserIdMapper {
+  toDiscordUserId: (userId: number) => Promise<string | null>;
+}


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

로컬 캐싱이 적용된 디스코드 유저 아이디 매퍼를 구현합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

- 메시지 전송 시 사이트 시스템 내 유저의 아이디는 알고 있지만 디스코드 유저의 아이디는 알 수 없습니다.
- 따라서, 메시지 전송 시 이러한 것들을 신경쓰지 않도록 메시지 전송 시 매핑하여 전송하도록 구현할 예정입니다.
- 이때, 디스코드 연동 정보는 왠만해서는 변하지 않으므로 1시간 단위로 캐시를 적용하여 속도 증가 및 쿼리 횟수를 감소시킵니다.