### PR TITLE
fix: 모듈에 등록 시 use class를 사용하도록 수정

### DIFF
--- a/src/app/AppModule.ts
+++ b/src/app/AppModule.ts
@@ -59,11 +59,11 @@ const entityMappers: Provider[] = [DiscordIntegrationMapper];
 const implementations: Provider[] = [
   {
     provide: DiscordUserIdMapperToken,
-    useValue: CachedDiscordUserIdMapper,
+    useClass: CachedDiscordUserIdMapper,
   },
   {
     provide: MessengerToken,
-    useValue: DiscordMessenger,
+    useClass: DiscordMessenger,
   },
 ];
 


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

클래스를 모듈에 등록할 때 `useValue` 대신 `useClass`를 사용하도록 수정합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

실수로 `useValue`를 넣어 주입이 의도와 다르게 되고 있던 문제가 있었습니다.