### PR TITLE
fix(Dockerfile): 잘못된 package lock 파일 이름 수정

### DIFF
--- a/Dockerfile.Build
+++ b/Dockerfile.Build
@@ -20,7 +20,7 @@ WORKDIR /sight
 # RUN corepack enable && corepack prepare yarn@4.6.0 --activate
 
 # COPY --from=builder /sight/package.json /sight/yarn.lock  ./
-COPY --from=builder /sight/package.json /sight/package-json.lock  ./
+COPY --from=builder /sight/package.json /sight/package-lock.json  ./
 COPY --from=builder /sight/.env.* ./
 COPY --from=builder /sight/node_modules/ ./node_modules/
 COPY --from=builder /sight/dist/ ./dist/


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

잘못 설정된 `package-lock.json` 파일의 이름을 수정합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

`package-json.lock`으로 되어 있었습니다.