### PR TITLE
chore: 컨테이너 이미지를 arm architecture 기준으로 빌드하도록 수정

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.Build
+          platforms: 'linux/arm64'
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

컨테이너 이미지를 arm arch 기준으로 빌드하도록 수정합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

컨테이너 실행 환경이 `arm64`(`t4g`)입니다. 하지만 생략하면 `amd` arch로 빌드되기 때문에, 정상적으로 실행되지 않습니다.