### PR TITLE
feat: 헬스 체크 api 구현

### DIFF
--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -9,6 +9,7 @@ import { AuthModule } from '@khlug/core/auth/AuthModule';
 import { configuration } from '@khlug/core/config';
 import { DatabaseConfig } from '@khlug/core/config/DatabaseConfig';
 import { DiscordModule } from '@khlug/core/discord/DiscordModule';
+import { HealthController } from '@khlug/core/health/HealthController';
 import { EntityModels } from '@khlug/core/persistence/Entities';
 
 @Global()
@@ -40,6 +41,7 @@ import { EntityModels } from '@khlug/core/persistence/Entities';
     CqrsModule,
     DiscordModule,
   ],
+  controllers: [HealthController],
   exports: [ClsModule, ConfigModule, MikroOrmModule, CqrsModule, DiscordModule],
 })
 export class CoreModule {}

--- a/src/core/health/HealthController.ts
+++ b/src/core/health/HealthController.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class HealthController {
+  @Get('/ping')
+  healthCheck() {
+    return 'pong!';
+  }
+}


### PR DESCRIPTION
### 주요 변경 사항
<!-- 해당 PR로 변경되는 사항을 한 눈에 알기 쉽게 정리해주세요. -->

헬스 체크 api를 구현합니다. 간단하게 서버가 살아있는지만 확인하기 위해 핑퐁 API로만 구현합니다.

### 변경 이유
<!-- 변경이 일어나는 이유를 한 눈에 알기 쉽게 정리해주세요. -->

ECS 등 서비스 상태를 알아내야 할 때가 있습니다. 이때 서버가 정상적으로 요청을 처리할 수 있는지를 확인하기 위해 헬스 체크 api를 구현하였습니다.